### PR TITLE
feat: pin (updated) cachix 1.4.1 for cachix watch-store

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "cachix_for_watch_store": {
+      "inputs": {
+        "devenv": "devenv",
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1680275997,
+        "narHash": "sha256-HhdfkBPS19z3rhxwn2k0fwbJUGGkh37t2LKH4zJsw5A=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "c6b3e8902ca7bffd43e2b278990e17f29b4cc99e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "v1.4.1",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -18,6 +39,30 @@
         "owner": "steveeJ-forks",
         "ref": "pr_gc_interval",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "flake-compat": [
+          "cachix_for_watch_store",
+          "flake-compat"
+        ],
+        "nix": "nix",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1679315774,
+        "narHash": "sha256-vflBVlzqGABkEbI+hS6jX+VQHDDdyL4lEToOBW8+weI=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "71f5c3c4344c9ef3d065de85386b5481c8f26abb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
         "type": "github"
       }
     },
@@ -41,6 +86,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -56,6 +117,44 @@
       "original": {
         "id": "flake-parts",
         "type": "indirect"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "cachix_for_watch_store",
+          "devenv",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
       }
     },
     "home-manager": {
@@ -151,18 +250,59 @@
         "url": "https://github.com/zippy.keys"
       }
     },
-    "nixpkgs": {
+    "lowdown-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1675273418,
-        "narHash": "sha256-tpYc4TEGvDzh9uRf44QemyQ4TpVuUbxb07b2P99XDbM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "4d7c2644dbac9cf8282c0afe68fca8f0f3e7b2db",
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": [
+          "cachix_for_watch_store",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1676545802,
+        "narHash": "sha256-EK4rZ+Hd5hsvXnzSzk2ikhStJnD63odF7SzsQ8CuSPU=",
+        "owner": "domenkozar",
+        "repo": "nix",
+        "rev": "7c91803598ffbcfe4a55c44ac6d49b2cf07a527f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "domenkozar",
+        "ref": "relaxed-flakes",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678875422,
+        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -185,8 +325,103 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1679281263,
+        "narHash": "sha256-neMref1GTruSLt1jBgAw+lvGsZj8arQYfdxvSi5yp4Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8276a165b9fa3db1a7a4f29ee29b680e0799b9dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1675273418,
+        "narHash": "sha256-tpYc4TEGvDzh9uRf44QemyQ4TpVuUbxb07b2P99XDbM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4d7c2644dbac9cf8282c0afe68fca8f0f3e7b2db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "cachix_for_watch_store",
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "cachix_for_watch_store",
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1678376203,
+        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "cachix_for_watch_store": "cachix_for_watch_store",
         "darwin": "darwin",
         "disko": "disko",
         "flake-parts": "flake-parts",
@@ -197,7 +432,7 @@
         "keys_steveej": "keys_steveej",
         "keys_thedavidmeister": "keys_thedavidmeister",
         "keys_zippy": "keys_zippy",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_3",
         "srvos": "srvos"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -79,18 +79,6 @@
         "type": "github"
       }
     },
-    "keys_davhau": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-0fd0gyrCTIDOPdmbPIKj7CD6696tiEumLZPoXqDd8dc=",
-        "type": "file",
-        "url": "https://github.com/davhau.keys"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://github.com/davhau.keys"
-      }
-    },
     "keys_jost-s": {
       "flake": false,
       "locked": {
@@ -203,7 +191,6 @@
         "disko": "disko",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
-        "keys_davhau": "keys_davhau",
         "keys_jost-s": "keys_jost-s",
         "keys_maackle": "keys_maackle",
         "keys_neonphog": "keys_neonphog",

--- a/flake.nix
+++ b/flake.nix
@@ -42,10 +42,6 @@
       url = "https://github.com/zippy.keys";
       flake = false;
     };
-    keys_davhau = {
-      url = "https://github.com/davhau.keys";
-      flake = false;
-    };
   };
 
   outputs = inputs @ {flake-parts, ...}:

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
       url = "https://github.com/zippy.keys";
       flake = false;
     };
+
+    cachix_for_watch_store.url = github:cachix/cachix/v1.4.1;
   };
 
   outputs = inputs @ {flake-parts, ...}:

--- a/modules/flake-parts/apps.deploy-/linux.nix
+++ b/modules/flake-parts/apps.deploy-/linux.nix
@@ -21,7 +21,7 @@
 
         ssh root@${hostName} nixos-rebuild \
           -j4 \
-          switch --flake /tmp/deploy-flake#'"${attrName}"'
+          "''${1:-switch}" --flake /tmp/deploy-flake#'"${attrName}"'
       '';
 
     mkLinuxDeployApp = attrName: config:

--- a/modules/nixos/cachix-watch.nix
+++ b/modules/nixos/cachix-watch.nix
@@ -1,4 +1,6 @@
 {
+  inputs,
+  pkgs,
   config,
   lib,
   magicPaths,
@@ -11,5 +13,6 @@
     jobs = 4;
     compressionLevel = 3;
     verbose = true;
+    package = inputs.cachix_for_watch_store.packages.${pkgs.system}.cachix;
   };
 }


### PR DESCRIPTION
already deployed to linux-builder-01 and it seems to have unstuck the builder.

i was previously stuck with this error:

```
Apr 04 09:27:59 linux-builder-01 cachix-watch-store-agent-start[721516]: compressing using zstd and pushing /nix/store/1clm8n21wjsja4dqg47px41hh6922vjw-rust_kitsune_p2p_types-0.2.0-beta-rc.1-lib (7.47 MiB)
Apr 04 09:27:59 linux-builder-01 cachix-watch-store-agent-start[721516]: cachix: CppStdException e "\ESC[31;1merror:\ESC[0m path '\ESC[35;1m/nix/store/bznx4kci9h8bsi4fndy2y22y44p1c1gb-holochain-tests-nextest-deps-workspace\ESC[0m' is not valid"(Just "nix::InvalidPath")
Apr 04 09:27:59 linux-builder-01 systemd[1]: cachix-watch-store-agent.service: Main process exited, code=exited, status=1/FAILURE
Apr 04 09:27:59 linux-builder-01 systemd[1]: cachix-watch-store-agent.service: Failed with result 'exit-code'.
```