### PR TITLE
feat(nix/gc): increase max-freed from 48 to 96 GiB

### DIFF
--- a/modules/nixos/macos.nix
+++ b/modules/nixos/macos.nix
@@ -4,7 +4,6 @@
   lib,
   ...
 }: {
-
   imports = [
     ./shared.nix
     ./shared-nix-settings.nix
@@ -12,7 +11,6 @@
 
   nix.settings.trusted-users = [
     "@admin"
-    "hetzner"
     config.deployUser
   ];
 
@@ -35,7 +33,7 @@
   # home-manager settings
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.users.hetzner = {
+  home-manager.users."${config.deployUser}" = {
     home.stateVersion = "22.11";
 
     # https://github.com/malob/nixpkgs/blob/master/home/default.nix

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -29,7 +29,7 @@
   nix.gc =
     {
       automatic = true;
-      options = lib.mkForce ''--max-freed "$((48* 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
+      options = lib.mkForce ''--max-freed "$((96* 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
     }
     // lib.optionalAttrs pkgs.stdenv.isLinux (lib.mkForce {
       # run at all minutes that are a multiple of 7


### PR DESCRIPTION
deployed to:
* [x] linux-builder-01
* [x] macos-01
* [x] macos-02 (there were some issues deploying on that due to a regression introduced via #27):
  ```
  + ssh administrator@hydra-minion-2.holo.host /tmp/next-system/sw/bin/darwin-rebuild -j4 switch --flake '/tmp/deploy-flake#"macos-02"'
  building the system configuration...
  user defaults...
  setting up user launchd services...
  setting up groups...
  updating group members builder...
  setting up users...
  setting up /Applications/Nix Apps...
  setting up pam...
  applying patches...
  setting up /etc...
  system defaults...
  setting up launchd services...
  reloading service org.nixos.activate-system
  reloading service org.nixos.nix-gc
  configuring networking...
  diff: /etc/nix/nix.conf.old: No such file or directory
  Activating home-manager configuration for hetzner
  sudo: unknown user: hetzner
  sudo: unable to initialize policy plugin
  ```
  addressed this in d06e2a3
* [x] macos-03
* [x] macos-04 (required a reboot)