### PR TITLE
chore(nix-darwin): update and adapt nix-gc options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -263,18 +263,6 @@
         "url": "https://github.com/jost-s.keys"
       }
     },
-    "keys_neonphog": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-InV0oto4PA8gLATCZxeP80V8QPrOxdJg0Qxfn0zaTa0=",
-        "type": "file",
-        "url": "https://github.com/neonphog.keys"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://github.com/neonphog.keys"
-      }
-    },
     "keys_steveej": {
       "flake": false,
       "locked": {
@@ -575,7 +563,6 @@
         "home-manager": "home-manager",
         "keys_artbrock": "keys_artbrock",
         "keys_jost-s": "keys_jost-s",
-        "keys_neonphog": "keys_neonphog",
         "keys_steveej": "keys_steveej",
         "keys_thetasinner": "keys_thetasinner",
         "nixos-anywhere": "nixos-anywhere",

--- a/flake.lock
+++ b/flake.lock
@@ -29,16 +29,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1677745326,
-        "narHash": "sha256-IoA8dUObRmYTHCadc/RxasKzYkrb4rVBtGWQoOMHm2k=",
+        "lastModified": 1692613703,
+        "narHash": "sha256-ByFRYQ8J4YSeAU6N0gUc5nmIjAGoiDU+jMUL73Ns0ZU=",
         "owner": "steveeJ-forks",
         "repo": "nix-darwin",
-        "rev": "7891240728852f1a728b082bee7a5cda6bfdda02",
+        "rev": "72d647c8bda6d8d8a88ba2b63b56ce4e0be57ea7",
         "type": "github"
       },
       "original": {
         "owner": "steveeJ-forks",
-        "ref": "pr_gc_interval",
+        "ref": "fork-fix-launchd-calendar-interval",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -39,10 +39,13 @@
     #   url = "https://github.com/maackle.keys";
     #   flake = false;
     # };
-    keys_neonphog = {
-      url = "https://github.com/neonphog.keys";
-      flake = false;
-    };
+
+    # hash mismatch 20230821
+    # keys_neonphog = {
+    #   url = "https://github.com/neonphog.keys";
+    #   flake = false;
+    # };
+
     # TODO: re-enable once the change is verified
     # keys_thedavidmeister = {
     #   url = "https://github.com/thedavidmeister.keys";

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,8 @@
     nixos-anywhere.inputs.nixpkgs.follows = "nixpkgs";
 
     # nix darwin
-    darwin.url = "github:steveeJ-forks/nix-darwin/pr_gc_interval";
+    darwin.url = "github:steveeJ-forks/nix-darwin/fork-fix-launchd-calendar-interval";
+
     darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     # home manager

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -40,7 +40,7 @@
     })
     // lib.optionalAttrs pkgs.stdenv.isDarwin {
       # run at all minutes that are a multiple of 7
-      intervals =
+      interval =
         builtins.map (Minute: {inherit Minute;}) (builtins.genList (n: n * 7) 9);
     };
 


### PR DESCRIPTION
the [upstream PR for this feature](https://github.com/LnL7/nix-darwin/pull/716/files) has not yet been merged so we depend on the rebased fork of the PR.

note: [our PR for this feature was closed in favor of PR we now depend on](https://github.com/LnL7/nix-darwin/pull/611)
