### PR TITLE
feat(build-distributor): temporarily shift from macos-01 to macos-04

### DIFF
--- a/modules/nixos/nix-build-distributor.nix
+++ b/modules/nixos/nix-build-distributor.nix
@@ -8,12 +8,13 @@
   nix.distributedBuilds = true;
   nix.buildMachines = [
     # macos-01
+    # currently broken and needs to be reinstalled
     {
       hostName = "167.235.13.208";
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "aarch64-darwin";
-      maxJobs = 4;
+      maxJobs = 0;
       supportedFeatures = config.nix.settings.experimental-features;
     }
     # macos-02
@@ -42,11 +43,18 @@
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "x86_64-darwin";
-      maxJobs = 0;
+      maxJobs = 2;
+      supportedFeatures = config.nix.settings.experimental-features;
+    }
+    {
+      hostName = "167.235.38.111";
+      sshUser = "builder";
+      protocol = "ssh-ng";
+      system = "aarch64-darwin";
+      maxJobs = 2;
       supportedFeatures = config.nix.settings.experimental-features;
     }
 
-    # currently not required as this machine runs the distributor
     # {
     #   hostName = "95.217.193.35";
     #   sshUser = "builder";

--- a/modules/nixos/nix-build-distributor.nix
+++ b/modules/nixos/nix-build-distributor.nix
@@ -7,7 +7,7 @@
 
   nix.distributedBuilds = true;
   nix.buildMachines = [
-    # macos-01
+    # macos-01 - system integrity protection enabled
     # currently broken and needs to be reinstalled
     {
       hostName = "167.235.13.208";
@@ -27,7 +27,7 @@
       supportedFeatures = config.nix.settings.experimental-features;
     }
 
-    # macos-03
+    # macos-03 - system integrity protection enabled
     {
       hostName = "142.132.140.224";
       sshUser = "builder";
@@ -37,13 +37,13 @@
       supportedFeatures = config.nix.settings.experimental-features;
     }
 
-    # macos-04
+    # macos-04 - system integrity protection disabled
     {
       hostName = "167.235.38.111";
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "x86_64-darwin";
-      maxJobs = 2;
+      maxJobs = 0;
       supportedFeatures = config.nix.settings.experimental-features;
     }
     {
@@ -51,7 +51,7 @@
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "aarch64-darwin";
-      maxJobs = 2;
+      maxJobs = 4;
       supportedFeatures = config.nix.settings.experimental-features;
     }
 


### PR DESCRIPTION
macos-01 is (most likely) currently in a broken state. once it's repaired and the system integrity protection is disabled we can reintroduce it as a x86_64-darwin builder while being able to evict the rosetta 2 cache.

- [x] deployed to linux-builder-01