### PR TITLE
feat(nix-gc): clean up 0-size drv files in under /nix/store

### DIFF
--- a/modules/flake-parts/nixosConfigurations.linux-builder-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-01/configuration.nix
@@ -19,6 +19,7 @@
 
     ../../nixos/shared.nix
     ../../nixos/shared-nix-settings.nix
+    ../../nixos/shared-linux.nix
   ];
 
   networking.hostName = "linux-builder-01"; # Define your hostname.

--- a/modules/nixos/macos.nix
+++ b/modules/nixos/macos.nix
@@ -8,6 +8,7 @@
   imports = [
     ./shared.nix
     ./shared-nix-settings.nix
+    ./shared-darwin.nix
   ];
 
   nix.settings.trusted-users = [

--- a/modules/nixos/shared-darwin.nix
+++ b/modules/nixos/shared-darwin.nix
@@ -1,7 +1,7 @@
 { config, lib, ...}: {
   launchd.daemons.nix-gc.command = lib.mkForce ''
     echo Removing 0-size derivations if any exist...
-    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs nix-store --delete --ignore-liveness
+    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs ${config.nix.package}/bin/nix-store --delete --ignore-liveness
 
     ${config.nix.package}/bin/nix-collect-garbage ${config.nix.gc.options}
   '';

--- a/modules/nixos/shared-darwin.nix
+++ b/modules/nixos/shared-darwin.nix
@@ -1,0 +1,8 @@
+{ config, lib, ...}: {
+  launchd.daemons.nix-gc.command = lib.mkForce ''
+    echo Removing 0-size derivations if any exist...
+    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs nix-store --delete --ignore-liveness
+
+    ${config.nix.package}/bin/nix-collect-garbage ${config.nix.gc.options}
+  '';
+}

--- a/modules/nixos/shared-darwin.nix
+++ b/modules/nixos/shared-darwin.nix
@@ -1,7 +1,8 @@
-{ config, lib, ...}: {
+{ config, lib, pkgs, ...}: let
+  cleanup0sizeDrvs = (import ./shared-linux.nix { inherit config pkgs; }).systemd.services.nix-gc.preStart;
+in {
   launchd.daemons.nix-gc.command = lib.mkForce ''
-    echo Removing 0-size derivations if any exist...
-    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs ${config.nix.package}/bin/nix-store --delete --ignore-liveness
+    ${cleanup0sizeDrvs}
 
     ${config.nix.package}/bin/nix-collect-garbage ${config.nix.gc.options}
   '';

--- a/modules/nixos/shared-darwin.nix
+++ b/modules/nixos/shared-darwin.nix
@@ -1,9 +1,9 @@
 { config, lib, pkgs, ...}: let
   cleanup0sizeDrvs = (import ./shared-linux.nix { inherit config pkgs; }).systemd.services.nix-gc.preStart;
 in {
-  launchd.daemons.nix-gc.command = lib.mkForce ''
+  launchd.daemons.nix-gc.command = lib.mkForce (pkgs.writeShellScript "nix-gc" ''
     ${cleanup0sizeDrvs}
 
     ${config.nix.package}/bin/nix-collect-garbage ${config.nix.gc.options}
-  '';
+  '');
 }

--- a/modules/nixos/shared-linux.nix
+++ b/modules/nixos/shared-linux.nix
@@ -1,6 +1,6 @@
 { config, ... }: {
   systemd.services.nix-gc.preStart = ''
     echo Removing 0-size derivations if any exist...
-    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs nix-store --delete --ignore-liveness
+    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs ${config.nix.package}/bin/nix-store --delete --ignore-liveness
   '';
 }

--- a/modules/nixos/shared-linux.nix
+++ b/modules/nixos/shared-linux.nix
@@ -1,6 +1,7 @@
-{ config, ... }: {
+{ config, pkgs, ... }: {
   systemd.services.nix-gc.preStart = ''
+    # if the machine runs low on disk space it's possible for derivation files to be created but never get content which results in derivations that can't be removed by the gc. this is a workaround which finds and deletes those problem derivations.
     echo Removing 0-size derivations if any exist...
-    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs ${config.nix.package}/bin/nix-store --delete --ignore-liveness
+    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | ${pkgs.findutils}/bin/xargs ${config.nix.package}/bin/nix-store --delete --ignore-liveness
   '';
 }

--- a/modules/nixos/shared-linux.nix
+++ b/modules/nixos/shared-linux.nix
@@ -1,0 +1,6 @@
+{ config, ... }: {
+  systemd.services.nix-gc.preStart = ''
+    echo Removing 0-size derivations if any exist...
+    ${config.nix.package}/bin/nix-store --query --referrers-closure $(find /nix/store -maxdepth 1 -type f -name '*.drv' -size 0)  | xargs nix-store --delete --ignore-liveness
+  '';
+}

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -2,12 +2,20 @@
   config,
   pkgs,
   lib,
+  system,
   ...
 }: let
 in {
   # Nix configuration shared between all hosts
 
-  imports = [./holo-deploy.nix];
+  imports = [
+    ./holo-deploy.nix
+  ]
+  # TODO: figure out why this results in infinite recursion
+  # ++ pkgs.stdenv.isLinux [
+  #   ./shared-linux.nix
+  # ]
+  ;
 
   nix.package = lib.mkDefault pkgs.nixVersions.nix_2_17;
 
@@ -32,7 +40,7 @@ in {
   nix.gc =
     {
       automatic = true;
-      options = lib.mkForce ''--max-freed "$((96* 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
+      options = lib.mkForce ''--max-freed "$((128* 1024**3 - 1024 * $(df -P -k /nix/store | tail -n 1 | ${pkgs.gawk}/bin/awk '{ print $4 }')))"'';
     }
     // lib.optionalAttrs pkgs.stdenv.isLinux (lib.mkForce {
       # run at all minutes that are a multiple of 7
@@ -80,4 +88,4 @@ in {
     else if config.deployUser == "root"
     then "/root"
     else "/home/${config.deployUser}";
-}
+} 


### PR DESCRIPTION
the current implementation isn't clean because of multiple aspects which can be improved subsequently. namely:

* no usage of platform conditional. instead using implicit knowledge about the configs.
* the shared cleanup command is duplicated
* on darwin, the nix-gc command is duplicated from the nix-darwin repo