### PR TITLE
feat(poc-2): change to running the remotev1 distributed test

### DIFF
--- a/nomad/commander.hcl
+++ b/nomad/commander.hcl
@@ -15,7 +15,7 @@ job "commander" {
   constraint {
     attribute = "${meta.HOLO_NIXPKGS_CHANNEL}"
     operator  = "regexp"
-    value     = ".*holo-nixpkgs/1694.*"
+    value     = ".*holo-nixpkgs/2021.*"
   }
 
   type = "sysbatch"
@@ -31,13 +31,13 @@ job "commander" {
       command = "/usr/bin/env"
       args = ["bash", "-c",
         <<-ENDOFSCRIPT
-          set -e
+          set -xe
           export NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/holo-nixpkgs/nixpkgs/
           nix-shell \
             -p nixos-rebuild \
             -p curl \
             -p sudo \
-            --command "/run/wrappers/bin/sudo /usr/bin/env hpos-update 1691"
+            --command "/run/wrappers/bin/sudo /usr/bin/env hpos-update 2021"
 
           # /run/wrappers/bin/sudo /usr/bin/env systemctl start holo-nixpkgs-auto-upgrade.service
         ENDOFSCRIPT

--- a/nomad/inspector.hcl
+++ b/nomad/inspector.hcl
@@ -18,6 +18,10 @@ job "inspector" {
     operator  = "is_set"
   }
 
+  constraint {
+      distinct_hosts = true
+  }
+
   type = "system"
 
   task "sleeper" {

--- a/nomad/poc-2.hcl
+++ b/nomad/poc-2.hcl
@@ -12,7 +12,7 @@
 */
 
 variables {
-    GIT_URL = "https://github.com/steveej-forks/holochain.git"
+    GIT_URL = "https://github.com/holochain/holochain.git"
     GIT_BRANCH = "pr_distributed-test-poc"
     agents = 5
     agents_readiness_timeout_secs = 720
@@ -71,6 +71,9 @@ job "poc-2" {
                     export TEST_SHARED_VALUES_REMOTEV1_ROLE="server"
                     export TEST_SHARED_VALUES_REMOTEV1_URL="ws://${NOMAD_HOST_IP_holochainTestRemoteV1}:${NOMAD_HOST_PORT_holochainTestRemoteV1}"
 
+                    # use practically infinite retries to bring the server back up after every run
+                    # will not retry in case of compilation errors, only for runs.
+                    # the test success is determined by the clients and the dev will purge the whole job (including this server) once the test is considered completed.
                     nix develop -vL .#coreDev --command \
                         cargo nextest run --locked -p holochain_test_utils --no-capture --features slow_tests --status-level=pass --retries=99999999 discovery_distributed
                     ENDOFSCRIPT
@@ -130,6 +133,7 @@ job "poc-2" {
                     <<ENDOFSCRIPT
                     set -xe
 
+                    # source the init script to inherit its PWD
                     source local/init.sh
                     env
 

--- a/nomad/poc-2/init.sh
+++ b/nomad/poc-2/init.sh
@@ -1,0 +1,27 @@
+#/usr/bin/env bash
+set -xeu
+
+pwd
+ls -lha
+
+export JOB_STATE_DIRECTORY="${STATE_DIRECTORY}/${NOMAD_JOB_ID}"
+
+mkdir -p "${JOB_STATE_DIRECTORY}"
+pushd "${JOB_STATE_DIRECTORY}"
+
+if [[ -d holochain/.git ]]; then
+    cd holochain
+    git status
+    git remote set-url origin ''${GIT_URL}
+    git fetch origin ''${GIT_BRANCH}
+    git checkout -B ''${GIT_BRANCH} origin/''${GIT_BRANCH}
+else
+    rm -rf holochain
+    git clone ''${GIT_URL} --depth 1 --single-branch --branch ''${GIT_BRANCH}
+    cd holochain
+fi
+
+git clean -fd
+git status
+
+ls -lha

--- a/nomad/poc-2/init.sh
+++ b/nomad/poc-2/init.sh
@@ -1,13 +1,13 @@
 #/usr/bin/env bash
-set -xeu
+set -xeu -o pipefail
 
 pwd
 ls -lha
 
+# this directory is persisted across job runs and can be used to persist state over time.
 export JOB_STATE_DIRECTORY="${STATE_DIRECTORY}/${NOMAD_JOB_ID}"
-
 mkdir -p "${JOB_STATE_DIRECTORY}"
-pushd "${JOB_STATE_DIRECTORY}"
+cd "${JOB_STATE_DIRECTORY}"
 
 if [[ -d holochain/.git ]]; then
     cd holochain


### PR DESCRIPTION
* use discovery_distributed test and add agents variable
* add init.sh
* recent change on this is to always use the same working directory per
  job-name
* tune retries/restarts and add readiness timeout variable
