### PR TITLE
make {turn,signal,bootstrap}-{0,1,2,3}.infra.holochain.org available

### DIFF
--- a/.github/workflows/turn-readiness-check.yml
+++ b/.github/workflows/turn-readiness-check.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs: {}
 
-env:
+env: {}
 
 jobs:
   lints:

--- a/README.md
+++ b/README.md
@@ -135,3 +135,13 @@ If the runners are back online then update the default profile
 ```shell
 nix run .#deploy-linux-builder-01 switch
 ```
+
+## TURN stack
+
+* [Adding a new machine]
+
+* Double-check that all TURN/Signal servers are ready:
+
+	```
+	nix run .#turn-readiness-check
+	```

--- a/docs/adding-a-turn-signal-bootstrap-combo-server.md
+++ b/docs/adding-a-turn-signal-bootstrap-combo-server.md
@@ -1,0 +1,114 @@
+This example adds the machine configuration `turn-2`.
+
+1. order a VPS on hetzner
+
+2. add 2 additional floating IPv4 addresses to it
+
+3. copy the flake-parts config and adjust the names
+    ```
+    cp -r modules/flake-parts/nixosConfigurations.turn-{1,2}
+    git add modules/flake-parts/nixosConfigurations.turn-2
+    sed -i 's/-1/-2/g' modules/flake-parts/nixosConfigurations.turn-2/*.nix
+    ```
+
+4. change the IP addresses in *modules/flake-parts/nixosConfigurations.turn-2/configuration.nix*.
+    these are the main and floating IPs of the VPS:
+
+    ```nix
+    (...)
+
+    }: let
+    hostName = "turn-2";
+
+    turnIpv4 = "65.109.140.0";
+    turnFqdn = "${hostName}.infra.holochain.org";
+
+    signalIpv4 = "95.217.25.40";
+    signalFqdn = "signal-2.infra.holochain.org";
+
+    bootstrapIpv4 = "95.216.176.124";
+    bootstrapFqdn = "bootstrap-2.infra.holochain.org";
+    in {
+
+    (...)
+
+5. add the DNS and reverse-proxy entries to *modules/flake-parts/nixosConfigurations.dweb-reverse-tls-proxy/configuration.nix*
+    * add entries for `{turn,signal,bootstrap}-2` to the bind config:
+        ```nix
+        (...)
+
+        environment.etc."bind/zones/${fqdn2domain}.zone" = {
+            enable = true;
+            user = "named";
+            group = "named";
+            mode = "0644";
+            text = ''
+
+            (...)
+
+            turn-2.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-2.config.services.holochain-turn-server.address}
+            signal-2.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-2.config.services.tx5-signal-server.address}
+            bootstrap-2.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-2.config.services.kitsune-bootstrap.address}
+            '';
+        };
+
+        (...)
+        ```
+
+    * add a reverse proxy entry to the caddy config:
+        ```nix
+        (...)
+
+        services.caddy.virtualHosts = {
+            (...)
+
+
+            "acme-turn-2.${fqdn2domain}:80" = {
+            extraConfig = ''
+                reverse_proxy http://turn-2.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-2.config.services.holochain-turn-server.nginx-http-port}
+            '';
+            };
+        };
+
+        (...)
+        ```
+
+6. rebuild the DNS server and restart the bind service
+    ```
+    nix run .\#deploy-dweb-reverse-tls-proxy switch
+    nix run .\#ssh-dweb-reverse-tls-proxy "systemctl restart bind"
+    ```
+
+7. verify the records
+    ```
+    nix run nixpkgs#dig +short {turn,signal,bootstrap}-2.infra.holochain.org @infra.holochain.org
+    65.109.140.0
+    95.217.25.40
+    95.216.176.124
+    ```
+8. deploy nixos on the new VPS. replace $IP with the primary IP of the VPS:
+
+    ```
+    nix run .#nixos-anywhere -- --flake .\#turn-2 root@$IP
+
+    (...)
+
+    ### Waiting for the maching to become reachable again ###
+    Warning: Permanently added '65.109.140.0' (ED25519) to the list of known hosts.
+    ### Done! ###
+    ```
+
+    this should take about 2-3 minutes.
+
+9. verify the functionality of the signal and turn stack.
+
+    ```
+    nix shell .#tx5 --command bash -c '
+        set -e;
+        turn-stress turn-2.infra.holochain.org 443 test test;
+        turn_doctor wss://signal-2.infra.holochain.org;
+        echo success
+    '
+    ```
+
+10. commit the changes to git and get them to develop

--- a/flake.lock
+++ b/flake.lock
@@ -76,7 +76,7 @@
     "crane": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-23-11"
+          "craneNixpkgs"
         ]
       },
       "locked": {
@@ -90,6 +90,22 @@
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
+        "type": "github"
+      }
+    },
+    "craneNixpkgs": {
+      "locked": {
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1018,6 +1034,7 @@
         "cachix_for_watch_store": "cachix_for_watch_store",
         "coturn": "coturn",
         "crane": "crane",
+        "craneNixpkgs": "craneNixpkgs",
         "darwin": "darwin",
         "disko": "disko",
         "flake-parts": "flake-parts",
@@ -1192,16 +1209,16 @@
     "tx5": {
       "flake": false,
       "locked": {
-        "lastModified": 1707175829,
-        "narHash": "sha256-Lkry9eEUk6aXe7aQ824YwkG2Ra44GPapIznGR2Ao/PA=",
+        "lastModified": 1710791497,
+        "narHash": "sha256-DfuppR6geBawupO8WnssXMZEOQxP0/FPPlfSmr93vlo=",
         "owner": "holochain",
         "repo": "tx5",
-        "rev": "d5fa9096eae2156618c701e87b7c40770faa123c",
+        "rev": "af0ecea9bee17f4e6230b15dd4af89bb0fc98bd9",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "tx5-signal-srv-v0.0.7-alpha",
+        "ref": "tx5-signal-srv-v0.0.8-alpha",
         "repo": "tx5",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,11 @@
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
 
+    # have the latest rust version available
+    craneNixpkgs = {url = "github:nixos/nixpkgs/nixos-unstable";};
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs-23-11";
+      inputs.nixpkgs.follows = "craneNixpkgs";
     };
 
     keys_steveej = {
@@ -81,7 +83,7 @@
 
     cachix_for_watch_store.url = "github:cachix/cachix/v1.5";
 
-    tx5.url = "github:holochain/tx5/tx5-signal-srv-v0.0.7-alpha";
+    tx5.url = "github:holochain/tx5/tx5-signal-srv-v0.0.8-alpha";
     tx5.flake = false;
 
     holochain-versions.url = "github:holochain/holochain?dir=versions/weekly";

--- a/modules/flake-parts/hardware.hetzner-cloud-ccx.nix
+++ b/modules/flake-parts/hardware.hetzner-cloud-ccx.nix
@@ -1,0 +1,46 @@
+{
+  # System independent arguments.
+  ...
+}: {
+  flake.nixosModules.hardware-hetzner-cloud-ccx = { ... }: {
+  boot.loader.grub.enable = false;
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  disko.devices.disk.sda = {
+    device = "/dev/sda";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          type = "EF00";
+          size = "1G";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "btrfs";
+            extraArgs = ["-f"]; # Override existing partition
+            subvolumes = {
+              # Subvolume name is different from mountpoint
+              "/rootfs" = {
+                mountpoint = "/";
+              };
+              "/nix" = {
+                mountOptions = ["noatime"];
+                mountpoint = "/nix";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  };
+}

--- a/modules/flake-parts/hardware.hetzner-cloud-ccx.nix
+++ b/modules/flake-parts/hardware.hetzner-cloud-ccx.nix
@@ -2,45 +2,45 @@
   # System independent arguments.
   ...
 }: {
-  flake.nixosModules.hardware-hetzner-cloud-ccx = { ... }: {
-  boot.loader.grub.enable = false;
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
+  flake.nixosModules.hardware-hetzner-cloud-ccx = {...}: {
+    boot.loader.grub.enable = false;
+    boot.loader.systemd-boot.enable = true;
+    boot.loader.efi.canTouchEfiVariables = true;
 
-  disko.devices.disk.sda = {
-    device = "/dev/sda";
-    type = "disk";
-    content = {
-      type = "gpt";
-      partitions = {
-        ESP = {
-          type = "EF00";
-          size = "1G";
-          content = {
-            type = "filesystem";
-            format = "vfat";
-            mountpoint = "/boot";
+    disko.devices.disk.sda = {
+      device = "/dev/sda";
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            type = "EF00";
+            size = "1G";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+            };
           };
-        };
-        root = {
-          size = "100%";
-          content = {
-            type = "btrfs";
-            extraArgs = ["-f"]; # Override existing partition
-            subvolumes = {
-              # Subvolume name is different from mountpoint
-              "/rootfs" = {
-                mountpoint = "/";
-              };
-              "/nix" = {
-                mountOptions = ["noatime"];
-                mountpoint = "/nix";
+          root = {
+            size = "100%";
+            content = {
+              type = "btrfs";
+              extraArgs = ["-f"]; # Override existing partition
+              subvolumes = {
+                # Subvolume name is different from mountpoint
+                "/rootfs" = {
+                  mountpoint = "/";
+                };
+                "/nix" = {
+                  mountOptions = ["noatime"];
+                  mountpoint = "/nix";
+                };
               };
             };
           };
         };
       };
     };
-  };
   };
 }

--- a/modules/flake-parts/hardware.hetzner-cloud-cpx.nix
+++ b/modules/flake-parts/hardware.hetzner-cloud-cpx.nix
@@ -1,0 +1,46 @@
+{
+  # System independent arguments.
+  ...
+}: {
+  flake.nixosModules.hardware-hetzner-cloud-cpx = {lib, ...}: {
+    boot.loader.systemd-boot.enable = false;
+    boot.loader.grub.efiSupport = false;
+
+    # forcing seems required or else there's an error about duplicated devices
+    boot.loader.grub.devices = lib.mkForce ["/dev/sda"];
+
+    disko.devices.disk.sda = {
+      device = "/dev/sda";
+      type = "disk";
+      content = {
+        type = "gpt";
+        partitions = {
+          boot = {
+            size = "1M";
+            type = "EF02"; # for grub MBR
+          };
+          root = {
+            size = "100%";
+            content = {
+              type = "btrfs";
+              extraArgs = ["-f"]; # Override existing partition
+              subvolumes = {
+                # Subvolume name is different from mountpoint
+                "/rootfs" = {
+                  mountpoint = "/";
+                };
+                "/nix" = {
+                  mountOptions = ["noatime"];
+                  mountpoint = "/nix";
+                };
+                "/boot" = {
+                  mountpoint = "/boot";
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.dweb-reverse-tls-proxy/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.dweb-reverse-tls-proxy/configuration.nix
@@ -196,6 +196,10 @@ in {
       turn-2.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-2.config.services.holochain-turn-server.address}
       signal-2.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-2.config.services.tx5-signal-server.address}
       bootstrap-2.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-2.config.services.kitsune-bootstrap.address}
+
+      turn-3.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-3.config.services.holochain-turn-server.address}
+      signal-3.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-3.config.services.tx5-signal-server.address}
+      bootstrap-3.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-3.config.services.kitsune-bootstrap.address}
     '';
   };
 
@@ -332,6 +336,12 @@ in {
     "acme-turn-2.${fqdn2domain}:80" = {
       extraConfig = ''
         reverse_proxy http://turn-2.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-2.config.services.holochain-turn-server.nginx-http-port}
+      '';
+    };
+
+    "acme-turn-3.${fqdn2domain}:80" = {
+      extraConfig = ''
+        reverse_proxy http://turn-3.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-3.config.services.holochain-turn-server.nginx-http-port}
       '';
     };
   };

--- a/modules/flake-parts/nixosConfigurations.dweb-reverse-tls-proxy/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.dweb-reverse-tls-proxy/configuration.nix
@@ -86,8 +86,9 @@ in {
   services.zerotierone = {
     enable = lib.mkDefault true;
   };
+
   nixpkgs.config.allowUnfreePredicate = pkg:
-    builtins.elem (lib.getName pkg) [
+    builtins.elem (builtins.trace (lib.getName pkg) (lib.getName pkg)) [
       "zerotierone"
       "nomad"
     ];
@@ -184,9 +185,17 @@ in {
 
       sj-bm-hostkey0.dev.${fqdn2domain}.       A       185.130.224.33
 
-      turn.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-infra-holochain-org.config.services.holochain-turn-server.address}
-      signal.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-infra-holochain-org.config.services.tx5-signal-server.address}
-      bootstrap.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-infra-holochain-org.config.services.kitsune-bootstrap.address}
+      turn-0.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-0.config.services.holochain-turn-server.address}
+      signal-0.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-0.config.services.tx5-signal-server.address}
+      bootstrap-0.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-0.config.services.kitsune-bootstrap.address}
+
+      turn-1.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-1.config.services.holochain-turn-server.address}
+      signal-1.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-1.config.services.tx5-signal-server.address}
+      bootstrap-1.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-1.config.services.kitsune-bootstrap.address}
+
+      turn-2.${fqdn2domain}.                     A       ${self.nixosConfigurations.turn-2.config.services.holochain-turn-server.address}
+      signal-2.${fqdn2domain}.                   A       ${self.nixosConfigurations.turn-2.config.services.tx5-signal-server.address}
+      bootstrap-2.${fqdn2domain}.                A       ${self.nixosConfigurations.turn-2.config.services.kitsune-bootstrap.address}
     '';
   };
 
@@ -308,9 +317,21 @@ in {
       '';
     };
 
-    "acme-turn.${fqdn2domain}:80" = {
+    "acme-turn-0.${fqdn2domain}:80" = {
       extraConfig = ''
-        reverse_proxy http://turn.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-infra-holochain-org.config.services.holochain-turn-server.nginx-http-port}
+        reverse_proxy http://turn-0.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-0.config.services.holochain-turn-server.nginx-http-port}
+      '';
+    };
+
+    "acme-turn-1.${fqdn2domain}:80" = {
+      extraConfig = ''
+        reverse_proxy http://turn-1.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-1.config.services.holochain-turn-server.nginx-http-port}
+      '';
+    };
+
+    "acme-turn-2.${fqdn2domain}:80" = {
+      extraConfig = ''
+        reverse_proxy http://turn-2.${fqdn2domain}:${builtins.toString self.nixosConfigurations.turn-2.config.services.holochain-turn-server.nginx-http-port}
       '';
     };
   };

--- a/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
@@ -48,7 +48,6 @@ in {
     "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
   ];
 
-
   # FIXME: is there a better way to do this?
   environment.etc."systemd/network/10-cloud-init-eth0.network.d/00-floating-ips.conf".text = ''
     [Network]

--- a/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
@@ -21,6 +21,7 @@ in {
     inputs.srvos.nixosModules.server
     inputs.srvos.nixosModules.mixins-terminfo
     inputs.srvos.nixosModules.hardware-hetzner-cloud
+    self.nixosModules.hardware-hetzner-cloud-ccx
 
     inputs.sops-nix.nixosModules.sops
 
@@ -47,11 +48,6 @@ in {
     "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
   ];
 
-  boot.loader.grub.enable = false;
-  boot.loader.systemd-boot.enable = true;
-  boot.loader.efi.canTouchEfiVariables = true;
-
-  boot.kernelPackages = pkgs.linuxPackages;
 
   # FIXME: is there a better way to do this?
   environment.etc."systemd/network/10-cloud-init-eth0.network.d/00-floating-ips.conf".text = ''
@@ -59,42 +55,6 @@ in {
     Address = ${signalIpv4}/32
     Address = ${bootstrapIpv4}/32
   '';
-
-  disko.devices.disk.sda = {
-    device = "/dev/sda";
-    type = "disk";
-    content = {
-      type = "gpt";
-      partitions = {
-        ESP = {
-          type = "EF00";
-          size = "1G";
-          content = {
-            type = "filesystem";
-            format = "vfat";
-            mountpoint = "/boot";
-          };
-        };
-        root = {
-          size = "100%";
-          content = {
-            type = "btrfs";
-            extraArgs = ["-f"]; # Override existing partition
-            subvolumes = {
-              # Subvolume name is different from mountpoint
-              "/rootfs" = {
-                mountpoint = "/";
-              };
-              "/nix" = {
-                mountOptions = ["noatime"];
-                mountpoint = "/nix";
-              };
-            };
-          };
-        };
-      };
-    };
-  };
 
   system.stateVersion = "23.05";
 

--- a/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-0/configuration.nix
@@ -5,14 +5,16 @@
   pkgs,
   ...
 }: let
+  hostName = "turn-0";
+
   turnIpv4 = "37.27.24.128";
-  turnFqdn = "turn.infra.holochain.org";
+  turnFqdn = "${hostName}.infra.holochain.org";
 
   signalIpv4 = "95.217.30.224";
-  signalFqdn = "signal.infra.holochain.org";
+  signalFqdn = "signal-0.infra.holochain.org";
 
   bootstrapIpv4 = "95.216.179.59";
-  bootstrapFqdn = "bootstrap.infra.holochain.org";
+  bootstrapFqdn = "bootstrap-0.infra.holochain.org";
 in {
   imports = [
     inputs.disko.nixosModules.disko
@@ -31,7 +33,7 @@ in {
     self.nixosModules.kitsune-bootstrap
   ];
 
-  networking.hostName = "turn-infra-holochain-org"; # Define your hostname.
+  networking.hostName = hostName; # Define your hostname.
 
   hostName = turnIpv4;
 

--- a/modules/flake-parts/nixosConfigurations.turn-0/default.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-0/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.turn-0 = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-1/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-1/configuration.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  ...
+}: let
+  hostName = "turn-1";
+
+  turnIpv4 = "65.109.5.38";
+  turnFqdn = "${hostName}.infra.holochain.org";
+
+  signalIpv4 = "95.217.243.165";
+  signalFqdn = "signal-1.infra.holochain.org";
+
+  bootstrapIpv4 = "65.109.242.27";
+  bootstrapFqdn = "bootstrap-1.infra.holochain.org";
+in {
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.mixins-terminfo
+    inputs.srvos.nixosModules.hardware-hetzner-cloud
+    self.nixosModules.hardware-hetzner-cloud-cpx
+
+    inputs.sops-nix.nixosModules.sops
+
+    self.nixosModules.holo-users
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+
+    self.nixosModules.holochain-turn-server
+    self.nixosModules.tx5-signal-server
+    self.nixosModules.kitsune-bootstrap
+  ];
+
+  networking.hostName = hostName; # Define your hostname.
+
+  hostName = turnIpv4;
+
+  nix.settings.max-jobs = 8;
+
+  nix.settings.substituters = [
+    "https://holochain-ci.cachix.org"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
+  ];
+
+  # FIXME: is there a better way to do this?
+  environment.etc."systemd/network/10-cloud-init-eth0.network.d/00-floating-ips.conf".text = ''
+    [Network]
+    Address = ${signalIpv4}/32
+    Address = ${bootstrapIpv4}/32
+  '';
+
+  system.stateVersion = "23.11";
+
+  services.holochain-turn-server = {
+    enable = true;
+    url = turnFqdn;
+    address = turnIpv4;
+    username = "test";
+    credential = "test";
+    verbose = false;
+    extraCoturnAttrs = {
+      cli-ip = "127.0.0.1";
+      cli-password = "$5$4c2b9a49c5e013ae$14f901c5f36d4c8d5cf0c7383ecb0f26b052134293152bd1191412641a20ddf5";
+    };
+  };
+
+  services.tx5-signal-server = {
+    enable = true;
+    address = signalIpv4;
+    port = 8443;
+    tls-port = 443;
+    url = signalFqdn;
+    iceServers = [
+      {
+        urls = [
+          "stun:${config.services.holochain-turn-server.url}:80"
+        ];
+      }
+      {
+        urls = [
+          "turn:${config.services.holochain-turn-server.url}:80"
+          "turn:${config.services.holochain-turn-server.url}:80?transport=tcp"
+          "turns:${config.services.holochain-turn-server.url}:443?transport=tcp"
+        ];
+
+        inherit
+          (config.services.holochain-turn-server)
+          username
+          credential
+          ;
+      }
+    ];
+  };
+
+  services.kitsune-bootstrap = {
+    enable = true;
+    address = bootstrapIpv4;
+    port = 8444;
+    tls-port = 443;
+    url = bootstrapFqdn;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-1/default.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-1/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.turn-1 = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-2/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-2/configuration.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  ...
+}: let
+  hostName = "turn-2";
+
+  turnIpv4 = "65.109.140.0";
+  turnFqdn = "${hostName}.infra.holochain.org";
+
+  signalIpv4 = "95.217.25.40";
+  signalFqdn = "signal-2.infra.holochain.org";
+
+  bootstrapIpv4 = "95.216.176.124";
+  bootstrapFqdn = "bootstrap-2.infra.holochain.org";
+in {
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.mixins-terminfo
+    inputs.srvos.nixosModules.hardware-hetzner-cloud
+    self.nixosModules.hardware-hetzner-cloud-cpx
+
+    inputs.sops-nix.nixosModules.sops
+
+    self.nixosModules.holo-users
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+
+    self.nixosModules.holochain-turn-server
+    self.nixosModules.tx5-signal-server
+    self.nixosModules.kitsune-bootstrap
+  ];
+
+  networking.hostName = hostName; # Define your hostname.
+
+  hostName = turnIpv4;
+
+  nix.settings.max-jobs = 8;
+
+  nix.settings.substituters = [
+    "https://holochain-ci.cachix.org"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "holochain-ci.cachix.org-2:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
+  ];
+
+  # FIXME: is there a better way to do this?
+  environment.etc."systemd/network/10-cloud-init-eth0.network.d/00-floating-ips.conf".text = ''
+    [Network]
+    Address = ${signalIpv4}/32
+    Address = ${bootstrapIpv4}/32
+  '';
+
+  system.stateVersion = "23.11";
+
+  services.holochain-turn-server = {
+    enable = true;
+    url = turnFqdn;
+    address = turnIpv4;
+    username = "test";
+    credential = "test";
+    verbose = false;
+    extraCoturnAttrs = {
+      cli-ip = "127.0.0.1";
+      cli-password = "$5$4c2b9a49c5e013ae$14f901c5f36d4c8d5cf0c7383ecb0f26b052134293152bd1191412641a20ddf5";
+    };
+  };
+
+  services.tx5-signal-server = {
+    enable = true;
+    address = signalIpv4;
+    port = 8443;
+    tls-port = 443;
+    url = signalFqdn;
+    iceServers = [
+      {
+        urls = [
+          "stun:${config.services.holochain-turn-server.url}:80"
+        ];
+      }
+      {
+        urls = [
+          "turn:${config.services.holochain-turn-server.url}:80"
+          "turn:${config.services.holochain-turn-server.url}:80?transport=tcp"
+          "turns:${config.services.holochain-turn-server.url}:443?transport=tcp"
+        ];
+
+        inherit
+          (config.services.holochain-turn-server)
+          username
+          credential
+          ;
+      }
+    ];
+  };
+
+  services.kitsune-bootstrap = {
+    enable = true;
+    address = bootstrapIpv4;
+    port = 8444;
+    tls-port = 443;
+    url = bootstrapFqdn;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-2/default.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-2/default.nix
@@ -4,7 +4,7 @@
   inputs,
   ...
 }: {
-  flake.nixosConfigurations.turn-infra-holochain-org = inputs.nixpkgs.lib.nixosSystem {
+  flake.nixosConfigurations.turn-2 = inputs.nixpkgs.lib.nixosSystem {
     modules = [./configuration.nix];
     system = "x86_64-linux";
     specialArgs = self.specialArgs;

--- a/modules/flake-parts/nixosConfigurations.turn-3/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-3/configuration.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  ...
+}: let
+  hostName = "turn-3";
+
+  turnIpv4 = "65.21.54.162";
+  turnFqdn = "${hostName}.infra.holochain.org";
+
+  signalIpv4 = "95.217.241.142";
+  signalFqdn = "signal-3.infra.holochain.org";
+
+  bootstrapIpv4 = "65.109.242.243";
+  bootstrapFqdn = "bootstrap-3.infra.holochain.org";
+in {
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.mixins-terminfo
+    inputs.srvos.nixosModules.hardware-hetzner-cloud
+    self.nixosModules.hardware-hetzner-cloud-cpx
+
+    inputs.sops-nix.nixosModules.sops
+
+    self.nixosModules.holo-users
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+
+    self.nixosModules.holochain-turn-server
+    self.nixosModules.tx5-signal-server
+    self.nixosModules.kitsune-bootstrap
+  ];
+
+  networking.hostName = hostName; # Define your hostname.
+
+  hostName = turnIpv4;
+
+  nix.settings.max-jobs = 8;
+
+  nix.settings.substituters = [
+    "https://holochain-ci.cachix.org"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "holochain-ci.cachix.org-3:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
+  ];
+
+  # FIXME: is there a better way to do this?
+  environment.etc."systemd/network/10-cloud-init-eth0.network.d/00-floating-ips.conf".text = ''
+    [Network]
+    Address = ${signalIpv4}/32
+    Address = ${bootstrapIpv4}/32
+  '';
+
+  system.stateVersion = "23.11";
+
+  services.holochain-turn-server = {
+    enable = true;
+    url = turnFqdn;
+    address = turnIpv4;
+    username = "test";
+    credential = "test";
+    verbose = false;
+    extraCoturnAttrs = {
+      cli-ip = "127.0.0.1";
+      cli-password = "$5$4c2b9a49c5e013ae$14f901c5f36d4c8d5cf0c7383ecb0f26b052134293152bd1191412641a20ddf5";
+    };
+  };
+
+  services.tx5-signal-server = {
+    enable = true;
+    address = signalIpv4;
+    port = 8443;
+    tls-port = 443;
+    url = signalFqdn;
+    iceServers = [
+      {
+        urls = [
+          "stun:${config.services.holochain-turn-server.url}:80"
+        ];
+      }
+      {
+        urls = [
+          "turn:${config.services.holochain-turn-server.url}:80"
+          "turn:${config.services.holochain-turn-server.url}:80?transport=tcp"
+          "turns:${config.services.holochain-turn-server.url}:443?transport=tcp"
+        ];
+
+        inherit
+          (config.services.holochain-turn-server)
+          username
+          credential
+          ;
+      }
+    ];
+  };
+
+  services.kitsune-bootstrap = {
+    enable = true;
+    address = bootstrapIpv4;
+    port = 8444;
+    tls-port = 443;
+    url = bootstrapFqdn;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-3/default.nix
+++ b/modules/flake-parts/nixosConfigurations.turn-3/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.turn-3 = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.turn-infra-holochain-org/README.md
+++ b/modules/flake-parts/nixosConfigurations.turn-infra-holochain-org/README.md
@@ -1,7 +1,0 @@
-This machine is of type CCX23
-
-# Installation
-
-```
-nix run github:numtide/nixos-anywhere -- --flake .\#nixosConfigurations.turn-infra-holochain-org root@turn.infra.holochain.org
-```

--- a/modules/flake-parts/packages.default.nix
+++ b/modules/flake-parts/packages.default.nix
@@ -1,10 +1,12 @@
 {
   # System independent arguments.
+  self,
   ...
 }: {
   perSystem = {
     # Arguments specific to the `perSystem` context.
     pkgs,
+    self',
     ...
   }: {
     # system specific outputs like, apps, checks, packages
@@ -13,8 +15,34 @@
       reverse-proxy-nix-cache = pkgs.writeShellScriptBin "reverse-proxy-nix-cache" ''
         sudo ${pkgs.caddy}/bin/caddy reverse-proxy --from :80 --to :5000
       '';
+
+      turn-readiness-check = pkgs.writeShellApplication {
+        name = "turn-readiness-check";
+        runtimeInputs = [
+          self'.packages.tx5
+        ];
+        text =
+          ''
+            set -e
+          ''
+          + builtins.concatStringsSep "\n" (builtins.map (
+              name: ''
+                echo "### checking ${name}... ###"
+                set -x
+                turn-stress ${name}.infra.holochain.org 443 test test
+                turn_doctor wss://${self.nixosConfigurations.${name}.config.services.tx5-signal-server.url}
+                set +x
+                echo "### checking ${name}: success ###"
+              ''
+            )
+            (builtins.filter (name: (builtins.match "turn-[0-9]+" name) != null) (builtins.attrNames self.nixosConfigurations)))
+          + ''
+            echo success
+          '';
+      };
     };
   };
+
   flake = {
     # system independent outputs like nixosModules, nixosConfigurations, etc.
 


### PR DESCRIPTION
* make turn-{0,1,2}.infra.holochain.org available
* document set up
* add basic readiness check
* abstract ccx and cpx hardware requirements

---

runs of the TURN readiness check workflow:
- :heavy_check_mark: https://github.com/holochain/holochain-infra/actions/runs/8389972367/job/22977282990

--- 

@zippy FYI `turn.infra.holochain.org` has been renamed to `turn-0.infra.holochain.org`

---

fixes https://github.com/holochain/holochain/issues/3479