### PR TITLE
feat: add modules and helper scripts for working with tfgrid/zos microvms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.minio/
 result*
 .decrypted~keys.yaml
 .storage

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,4 +1,4 @@
-# This example uses YAML anchors which allows reuse of multiple keys 
+# This example uses YAML anchors which allows reuse of multiple keys
 # without having to repeat yourself.
 # Also see https://github.com/Mic92/dotfiles/blob/master/nixos/.sops.yaml
 # for a more complex example.
@@ -8,6 +8,7 @@ keys:
   - &jost-s D299483493EAE6B2B3D892B6D33548FA55FF167F
   - &dweb-reverse-proxy age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
   - &linux-builder-01 age1kxkr407jz77ljrhgsfwfmv2yvqjprc6unvx389xp2f48xj8r0vqq2wew5r
+  - &tfgrid-shared age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
 
 creation_rules:
   - path_regex: ^(.+/|)secrets/[^/]+$
@@ -33,6 +34,7 @@ creation_rules:
       # - *jost-s
       age:
       - *dweb-reverse-proxy
+      - *tfgrid-shared
   - path_regex: ^secrets/nomad/admin/.+$
     key_groups:
     - pgp:

--- a/flake.lock
+++ b/flake.lock
@@ -374,6 +374,23 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -694,6 +711,21 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1711241261,
+        "narHash": "sha256-knrTvpl81yGFHIpm1SsLDApe0thFkw1cl3ISAMPmP/0=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "b2a1eeef8c185f6bd27432b053ff09d773244cbc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixos-2305": {
       "locked": {
         "lastModified": 1686478675,
@@ -732,6 +764,27 @@
       "original": {
         "owner": "numtide",
         "repo": "nixos-anywhere",
+        "type": "github"
+      }
+    },
+    "nixos-generators": {
+      "inputs": {
+        "nixlib": "nixlib",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711327729,
+        "narHash": "sha256-RzOXI1kBlK7HkeZfRjUnsBUJEmlMYgLEG7CziZN0lgs=",
+        "owner": "nix-community",
+        "repo": "nixos-generators",
+        "rev": "d3e8145766dad6b47f6e37ce28731a05144dec26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-generators",
         "type": "github"
       }
     },
@@ -1031,6 +1084,7 @@
         "keys_zippy": "keys_zippy",
         "microvm": "microvm",
         "nixos-anywhere": "nixos-anywhere",
+        "nixos-generators": "nixos-generators",
         "nixpkgs": [
           "nixpkgs-23-11"
         ],
@@ -1040,6 +1094,7 @@
         "nixpkgsUnstable": "nixpkgsUnstable",
         "sops-nix": "sops-nix",
         "srvos": "srvos",
+        "threefold-rfs": "threefold-rfs",
         "tx5": "tx5"
       }
     },
@@ -1057,6 +1112,31 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "a1b17cacfa7a6ed18f553a195a047f4e73e95da9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "threefold-rfs",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "threefold-rfs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712542394,
+        "narHash": "sha256-UZebDBECRSrJqw4K+LxZ6qFdYnScu6q1XCwqtsu1cas=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ece8bdb3c3b58def25f204b9a1261dee55d7c9c0",
         "type": "github"
       },
       "original": {
@@ -1165,6 +1245,47 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "threefold-rfs": {
+      "inputs": {
+        "crane": [
+          "crane"
+        ],
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1712589330,
+        "narHash": "sha256-YP9g3MMj2mRfD+mrOKNOvRTBADXIzawKW0dXVTIes1Y=",
+        "owner": "steveej-forks",
+        "repo": "threefold-rfs",
+        "rev": "fea8812b4085e313ede38380b1345a70e662fb01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steveej-forks",
+        "ref": "configure-pool-pin-rust",
+        "repo": "threefold-rfs",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,18 @@
       flake = false;
       url = "github:steveej-forks/coturn/debug-cli-login";
     };
+
+    nixos-generators = {
+      url = "github:nix-community/nixos-generators";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    threefold-rfs = {
+      url = "github:steveej-forks/threefold-rfs/configure-pool-pin-rust";
+      # url = "github:threefoldtech/rfs/configure-pool";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.crane.follows = "crane";
+    };
   };
 
   outputs = inputs @ {
@@ -114,6 +126,7 @@
         self',
         inputs',
         pkgs,
+        lib,
         ...
       }: {
         # Per-system attributes can be defined here. The self' and inputs'
@@ -125,40 +138,54 @@
           nomadClientCert = ./secrets/nomad/cli/global-cli-nomad.pem;
         in
           pkgs.mkShell {
-            packages = [
-              pkgs.yq-go
+            packages =
+              [
+                pkgs.yq-go
 
-              inputs'.nixos-anywhere.packages.default
+                inputs'.nixos-anywhere.packages.default
 
-              inputs'.sops-nix.packages.default
-              pkgs.ssh-to-age
-              pkgs.age
-              pkgs.age-plugin-yubikey
-              pkgs.sops
+                inputs'.sops-nix.packages.default
+                pkgs.ssh-to-age
+                pkgs.age
+                pkgs.age-plugin-yubikey
+                pkgs.sops
 
-              self'.packages.nomad
+                # self'.packages.nomad
 
-              (pkgs.writeShellScriptBin "nomad-ui-proxy" (let
-                caddyfile = pkgs.writeText "caddyfile" ''
-                  {
-                    auto_https off
-                    http_port 2016
-                  }
+                (pkgs.writeShellScriptBin "nomad-ui-proxy" (let
+                  caddyfile = pkgs.writeText "caddyfile" ''
+                    {
+                      auto_https off
+                      http_port 2016
+                    }
 
-                  localhost:2016 {
-                    reverse_proxy ${nomadAddr} {
-                      transport http {
-                        tls_trusted_ca_certs ${nomadCaCert}
-                        tls_client_auth ${nomadClientCert} {$NOMAD_CLIENT_KEY}
+                    localhost:2016 {
+                      reverse_proxy ${nomadAddr} {
+                        transport http {
+                          tls_trusted_ca_certs ${nomadCaCert}
+                          tls_client_auth ${nomadClientCert} {$NOMAD_CLIENT_KEY}
+                        }
                       }
                     }
-                  }
-                '';
-              in ''
-                ${pkgs.caddy}/bin/caddy run --adapter caddyfile --config ${caddyfile}
-              ''))
-              pkgs.caddy
-            ];
+                  '';
+                in ''
+                  ${pkgs.caddy}/bin/caddy run --adapter caddyfile --config ${caddyfile}
+                ''))
+                pkgs.caddy
+
+                inputs'.threefold-rfs.packages.default
+
+                pkgs.jq
+              ]
+              ++ (
+                let
+                  zosCmds = builtins.filter (pkg: null != (builtins.match "^zos-.*" pkg.name)) (builtins.attrValues self'.packages);
+                in
+                  zosCmds
+                  ++ (lib.lists.flatten (builtins.map (cmd: cmd.nativeBuildInputs or []) zosCmds))
+                  ++ (lib.lists.flatten (builtins.map (cmd: cmd.buildInputs or []) zosCmds))
+                  ++ (lib.lists.flatten (builtins.map (cmd: cmd.runtimeInputs or []) zosCmds))
+              );
 
             NOMAD_ADDR = nomadAddr;
             NOMAD_CACERT = nomadCaCert;

--- a/lib/make-system-directory.nix
+++ b/lib/make-system-directory.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, closureInfo
+, pixz
+
+, # The files and directories to be placed in the directory.
+  # This is a list of attribute sets {source, target} where `source'
+  # is the file system object (regular file or directory) to be
+  # grafted in the file system at path `target'.
+  contents
+
+, # In addition to `contents', the closure of the store paths listed
+  # in `packages' are also placed in the Nix store of the tarball.  This is
+  # a list of attribute sets {object, symlink} where `object' if a
+  # store path whose closure will be copied, and `symlink' is a
+  # symlink to `object' that will be added to the tarball.
+  storeContents ? [ ]
+
+  # Extra commands to be executed before archiving files
+, extraCommands ? ""
+
+  # extra inputs
+, extraInputs ? [ ]
+}:
+
+let
+  symlinks = map (x: x.symlink) storeContents;
+  objects = map (x: x.object) storeContents;
+in
+
+stdenv.mkDerivation {
+  name = "system-directory";
+  builder = ./make-system-directory.sh;
+  nativeBuildInputs = extraInputs;
+
+  inherit extraCommands;
+
+  # !!! should use XML.
+  sources = map (x: x.source) contents;
+  targets = map (x: x.target) contents;
+
+  # !!! should use XML.
+  inherit symlinks objects;
+
+  closureInfo = closureInfo {
+    rootPaths = objects;
+  };
+}

--- a/lib/make-system-directory.sh
+++ b/lib/make-system-directory.sh
@@ -1,0 +1,53 @@
+source $stdenv/setup
+
+sources_=($sources)
+targets_=($targets)
+
+objects=($objects)
+symlinks=($symlinks)
+
+# Remove the initial slash from a path, since genisofs likes it that way.
+stripSlash() {
+  res="$1"
+  if test "${res:0:1}" = /; then res=${res:1}; fi
+}
+
+# Add the individual files.
+for ((i = 0; i < ${#targets_[@]}; i++)); do
+  stripSlash "${targets_[$i]}"
+  mkdir -p "$(dirname "$res")"
+  cp -a "${sources_[$i]}" "$res"
+done
+
+# Add the closures of the top-level store objects.
+chmod +w .
+mkdir -p nix/store
+for i in $(<$closureInfo/store-paths); do
+  cp -a "$i" "${i:1}"
+done
+
+# TODO tar ruxo
+# Also include a manifest of the closures in a format suitable for
+# nix-store --load-db.
+cp $closureInfo/registration nix-path-registration
+
+# Add symlinks to the top-level store objects.
+for ((n = 0; n < ${#objects[*]}; n++)); do
+  object=${objects[$n]}
+  symlink=${symlinks[$n]}
+  if test "$symlink" != "none"; then
+    mkdir -p $(dirname ./$symlink)
+    ln -s $object ./$symlink
+  fi
+done
+
+$extraCommands
+
+rm env-vars
+
+mkdir $out
+cp -a --reflink=always * $out/
+
+mkdir -p $out/nix-support
+echo $system >$out/nix-support/system
+echo "file system-directory $out" >$out/nix-support/hydra-build-products

--- a/modules/flake-parts/nixosConfigurations.tfgrid-base/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.tfgrid-base/configuration.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  lib,
+  ...
+}: let
+  hostName = "tfgrid-base";
+in {
+  imports = [
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.mixins-terminfo
+
+    self.nixosModules.holo-users
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+
+    self.nixosModules.zosVmDir
+  ];
+
+  # srvos' server module sets this with lib.mkDefault (1000) so go slightly higher in priority (lower in number)
+  networking.hostName = lib.mkOverride 999 hostName;
+
+  nix.settings.substituters = [
+    "https://holochain-ci.cachix.org"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
+  ];
+
+  system.stateVersion = "23.11";
+}

--- a/modules/flake-parts/nixosConfigurations.tfgrid-base/default.nix
+++ b/modules/flake-parts/nixosConfigurations.tfgrid-base/default.nix
@@ -1,0 +1,14 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.tfgrid-base = inputs.nixpkgs.lib.nixosSystem {
+    modules = [
+      ./configuration.nix
+    ];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.tfgrid-devnet-vm0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.tfgrid-devnet-vm0/configuration.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  ...
+}: let
+  hostName = "tfgrid-devnet-vm0";
+in {
+  imports = [
+    ../nixosConfigurations.tfgrid-base/configuration.nix
+
+    inputs.sops-nix.nixosModules.sops
+
+    self.nixosModules.nomad-client
+  ];
+
+  sops.age.keyFile = "/etc/age.key";
+
+  environment.systemPackages = [
+    pkgs.iperf3
+    pkgs.man
+  ];
+
+  holochain-infra.nomad-client = {
+    enable = true;
+    machineType = "zos-vm";
+  };
+
+  networking.hostName = hostName;
+}

--- a/modules/flake-parts/nixosConfigurations.tfgrid-devnet-vm0/default.nix
+++ b/modules/flake-parts/nixosConfigurations.tfgrid-devnet-vm0/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.tfgrid-devnet-vm0 = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/flake-parts/packages.zos-utils.nix
+++ b/modules/flake-parts/packages.zos-utils.nix
@@ -1,0 +1,271 @@
+{
+  # System independent arguments.
+  ...
+}: {
+  perSystem = {
+    # Arguments specific to the `perSystem` context.
+    pkgs,
+    inputs',
+    ...
+  }: {
+    packages = let
+      configName = "tfgrid-base";
+    in
+      {
+        zos-vm-build = pkgs.writeShellApplication {
+          name = "zos-vm-build";
+          text = ''
+            set -xueE -o pipefail
+
+            ts="''${1:-"$(date +"%Y%m%d.%H%M%S")"}"
+
+            resultName="${configName}.$ts"
+
+            mkdir -p results
+
+            nix build --out-link results/"$resultName" \
+              .\#nixosConfigurations."${configName}".config.system.build.zosVmDir
+            ln -sf --no-target-directory "$resultName" results/"${configName}.latest"
+
+            echo results/"$resultName"
+          '';
+        };
+
+        # TODO: automate proper minio hosting. this is exemplary only and requires imperative setup of minio
+        zos-vm-serve-s3 = pkgs.writeShellApplication {
+          name = "zos-vm-serve-s3";
+          runtimeInputs = [
+            pkgs.minio
+          ];
+          text = ''
+            set -ueE -o pipefail
+
+            cd .minio
+
+            env \
+              MINIO_ROOT_USER=minioadmin \
+              MINIO_ROOT_PASSWORD="$(cat minioadmin.key)" \
+              minio server --console-address ":9001" storage
+          '';
+        };
+
+        zos-vm-publish-s3 = let
+          s3BaseUrl = "sj-bm-hostkey0.dev.infra.holochain.org";
+          s3ListenUrl = "${s3BaseUrl}:9000";
+          s3HttpUrl = "https://${s3BaseUrl}/s3";
+          s3Bucket = "tfgrid-eval";
+        in
+          pkgs.writeShellApplication {
+            name = "zos-vm-publish-s3";
+            runtimeInputs = [
+              pkgs.minio-client
+            ];
+            text = ''
+              set -xueE -o pipefail
+
+              rootfsRel="$1"
+              rootfsBase="$(basename "$rootfsRel")"
+              rootfsDir="$(dirname "$rootfsRel")"
+              rootfs="$(realpath "$rootfsRel")"
+
+              workDir="$rootfsDir"/"$rootfsBase".work
+
+              mkdir -p "$workDir"
+              cd "$workDir"
+
+              # mc rm --recursive --force localhost/${s3Bucket} || echo removal failed
+              env RUST_MIN_STACK=8388608 \
+                rfs pack -m result.fl -s s3://minioadmin:"$(cat ../../.minio/minioadmin.key)"@${s3ListenUrl}/${s3Bucket}\?region=us-east-1 "$rootfs/" | tee rfs-pack.log
+
+              # TODO: document or automate setting up the alias "localhost"
+              mc cp result.fl localhost/${s3Bucket}/"$rootfsBase".fl
+              echo ${s3HttpUrl}/${s3Bucket}/"$rootfsBase".fl > public-url
+
+              touch published
+
+              echo "$workDir"/result.fl
+            '';
+          };
+      }
+      // (
+        let
+          macaddr = "12:34:56:78:90:ab";
+          userData = pkgs.writeText "user-data" ''
+            #cloud-config
+
+            ssh_pwauth: True
+          '';
+          metaData = pkgs.writeText "meta-data" ''
+            instance-id: tfgrid
+            local-hostname: tfgrid
+          '';
+          networkConfig = pkgs.writeText "network-config" ''
+            version: 2
+            ethernets:
+              id0:
+                match:
+                  macaddress: '${macaddr}'
+                dhcp4: false
+                addresses: [192.168.249.2/24]
+                gateway4: 192.168.249.1
+          '';
+          # see https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/scripts/create-cloud-init.sh
+          cloudinitImg =
+            pkgs.runCommand "cloudinit.img"
+            {
+              nativeBuildInputs = [pkgs.dosfstools pkgs.mtools];
+            } ''
+              mkdosfs -n CIDATA -C "$out" 8192
+
+              # TODO: clarify whether the name needs to match
+              cp ${userData} user-data
+              mcopy -oi "$out" -s user-data ::
+
+              cp ${metaData} meta-data
+              mcopy -oi "$out" -s meta-data ::
+
+              cp ${networkConfig} network-config
+              mcopy -oi "$out" -s network-config ::
+            '';
+        in {
+          zos-vm-boot-local = pkgs.writeShellApplication {
+            # see https://gist.github.com/muhamadazmy/a10bfb0cc77084c9b09dea5e49ec528e
+            name = "zos-vm-boot-local";
+            runtimeInputs = [
+              pkgs.virtiofsd
+              pkgs.cloud-hypervisor
+            ];
+            text = ''
+              set -xeuE -o pipefail
+
+              # path to root directory
+              rootfs="''${1}"
+              kernel="$rootfs/boot/vmlinuz"
+              initram="$rootfs/boot/initrd.img"
+
+              workDir="$rootfs.work"
+              mkdir -p "$workDir"
+
+              socket="$workDir/virtiofs.sock"
+
+              fail() {
+                  echo "$1" >&2
+                  exit 1
+              }
+
+              if [ ! -f "$kernel" ]; then
+                  fail "kernel file not found"
+              fi
+
+              if [ ! -f "$initram" ]; then
+                  fail "kernel file not found"
+              fi
+
+              # start virtiofsd in the background
+              sudo virtiofsd -d --socket-path="$socket" --shared-dir="$rootfs/" &>/dev/null &
+              fspid="$!"
+
+              sleep 1
+
+              cleanup() {
+                (
+                  set +eEu
+
+                  sudo kill "$fspid"
+                  rm -rf "$socket"
+                )
+              }
+
+              trap cleanup EXIT
+
+              sudo cloud-hypervisor \
+                  --memory size=2048M,shared=on \
+                  --disk path=${cloudinitImg},readonly=true \
+                  --net "tap=,mac=${macaddr},ip=,mask=" \
+                  --kernel "$kernel" \
+                  --initramfs "$initram" \
+                  --fs tag=vroot,socket="$socket" \
+                  --cmdline "rw console=ttyS0 boot.shell_on_fail" \
+                  --serial tty \
+                  --console off
+            '';
+
+            # --cmdline "rw console=ttyS0 init=$init boot.shell_on_fail boot.debug1mounts" \
+          };
+          zos-vm-boot-s3 = pkgs.writeShellApplication {
+            # see https://gist.github.com/muhamadazmy/a10bfb0cc77084c9b09dea5e49ec528e
+            name = "zos-vm-boot-s3";
+            runtimeInputs = [
+              pkgs.virtiofsd
+              pkgs.cloud-hypervisor
+              inputs'.threefold-rfs.packages.default
+            ];
+            text = ''
+              set -xeuE -o pipefail
+
+              # path to root directory
+              rootfs="''${1}"
+              kernel="$rootfs/boot/vmlinuz"
+              initram="$rootfs/boot/initrd.img"
+
+              workDir="$rootfs.work"
+              mountDir="$workDir/mnt"
+              mkdir -p "$mountDir"
+
+              socket="$workDir/virtiofs.sock"
+
+              fail() {
+                  echo "$1" >&2
+                  exit 1
+              }
+
+              rfs mount -m "$workDir"/result.fl "$mountDir" > "$workDir"/rfs_mount.log 2>&1 &
+              mountpid="$!"
+
+              sleep 3
+
+              if [ ! -f "$kernel" ]; then
+                  fail "kernel file not found"
+              fi
+
+              if [ ! -f "$initram" ]; then
+                  fail "kernel file not found"
+              fi
+
+              # start virtiofsd in the background
+              sudo virtiofsd -d --socket-path="$socket" --shared-dir="$mountDir" &>/dev/null &
+              fspid="$!"
+
+              cleanup() {
+                (
+                  set +eEu
+
+                  sudo kill "$fspid"
+                  rm -rf "$socket"
+
+                  kill "$mountpid"
+                  umount --lazy "$mountDir"
+                  rmdir "$mountDir"
+                )
+              }
+
+              trap cleanup EXIT
+
+              sudo cloud-hypervisor \
+                  --memory size=2048M,shared=on \
+                  --disk path=${cloudinitImg},readonly=true \
+                  --net "tap=,mac=${macaddr},ip=,mask=" \
+                  --kernel "$kernel" \
+                  --initramfs "$initram" \
+                  --fs tag=vroot,socket="$socket" \
+                  --cmdline "rw console=ttyS0 boot.shell_on_fail" \
+                  --serial tty \
+                  --console off
+            '';
+
+            # --cmdline "rw console=ttyS0 init=$init boot.shell_on_fail boot.debug1mounts" \
+          };
+        }
+      );
+  };
+}

--- a/modules/flake-parts/tfgrid-microvm/default.nix
+++ b/modules/flake-parts/tfgrid-microvm/default.nix
@@ -1,0 +1,133 @@
+# TODO: make sure new kernels/initrds also get copied to `/boot/vmlinuz` and `/boot/initrd.mg`
+{self, ...}: {
+  flake.nixosModules = {
+    zosVmDir = {
+      config,
+      lib,
+      modulesPath,
+      pkgs,
+      ...
+    }: let
+      mkZosVmDir = import ./mk-zos-vm-dir.nix;
+
+      bootFiles = pkgs.runCommandNoCC "bootfiles" {} ''
+        mkdir $out
+        ${pkgs.gcc}/bin/strip ${config.system.build.kernel.dev}/vmlinux -o $out/vmlinuz
+        cp ${config.system.build.initialRamdisk}/initrd $out/initrd.img
+      '';
+    in {
+      imports = [
+        (modulesPath + "/profiles/qemu-guest.nix")
+        self.nixosModules.zosVmDirOverlayAutodetect
+      ];
+      # can be built with
+      # nix build -v .\#nixosConfigurations.<name>.config.system.build.zosVmDir
+      system.build.zosVmDir = mkZosVmDir {inherit self pkgs config bootFiles;};
+
+      fileSystems."/" = {
+        device = "vroot";
+        fsType = "virtiofs";
+      };
+
+      boot.initrd.kernelModules = [
+        "virtiofs"
+        "virtio_blk"
+        "virtio_pmem"
+        "virtio_console"
+        "virtio_pci"
+        "virtio_mmio"
+      ];
+
+      boot.loader.grub.enable = false;
+      boot.initrd.systemd.enable = false;
+
+      boot.loader.external.enable = true;
+      # the first argument points to the new system's toplevel, which is equivalent to config.system.build.toplevel
+      boot.loader.external.installHook = pkgs.writeShellScript "noop" ''
+        ${pkgs.coreutils}/bin/ln -sf "$1"/init /init
+        ${pkgs.coreutils}/bin/ln -sf ${bootFiles}/vmlinuz /boot/vmlinuz
+        ${pkgs.coreutils}/bin/ln -sf  ${bootFiles}/initrd.img /boot/initrd.img
+      '';
+
+      services.cloud-init.enable = true;
+      services.cloud-init.ext4.enable = true;
+      services.cloud-init.network.enable = true;
+
+      boot.kernelParams = ["nomodeset"];
+      networking.useDHCP = false;
+
+      # force SSH to start
+      services.openssh.enable = true;
+      systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
+      # systemd.services.sshd.after = lib.mkForce [ ];
+
+      # changes for format.docker
+      networking.useHostResolvConf = false;
+
+      environment.systemPackages = [
+        (pkgs.writeShellScriptBin "nixos-rebuild-helper" ''
+          set -xeEu -o pipefail
+
+          FLAKE="''${FLAKE:-github:holochain/holochain-infra/workorch-zos#tfgrid-devnet-vm0}"
+
+          case "$1" in
+            replace-init)
+              result="$(nix build --refresh --tarball-ttl 0 "''${FLAKE}.config.system.build.toplevel" --print-out-paths --no-link)"
+              ln -sf "''${result}"/init /init
+              ;;
+            switch)
+              exec nixos-rebuild --refresh --flake "''${FLAKE}" switch
+              ;;
+            boot)
+              exec nixos-rebuild --refresh --flake "''${FLAKE}" switch
+              ;;
+          esac
+        '')
+      ];
+    };
+
+    zosVmDirOverlayAutodetect = {lib, ...}: {
+      boot.initrd.kernelModules = [
+        "overlay"
+      ];
+
+      # use an overlay on a tmpfs because the rfs mount is read-only
+      boot.initrd.postMountCommands = let
+        target = "/mnt-root";
+        targetRo = "${target}-ro";
+
+        # TODO: make this these are sane and work
+        overlay = rec {
+          base = "/overlay";
+          upper = "${base}/rw/upper";
+          work = "${base}/rw/work";
+          lower = "${base}/ro";
+        };
+      in ''
+        set -x
+        if ! touch ${target}/.read-write; then
+          # move the rootfs mount out of the way for the tmpfs
+          mkdir -p ${targetRo}
+          mount --move ${target} ${targetRo}
+
+          # create a new tmpfs for the overlay
+          mount -t tmpfs none -o size=4G,mode=755 ${target}
+
+          # assemble and the overlay
+          mkdir -p ${overlay.upper} ${overlay.work} ${overlay.lower}
+          mount --move ${targetRo} ${overlay.lower}
+          mount -t overlay overlay -o upperdir=${overlay.upper},workdir=${overlay.work},lowerdir=${overlay.lower} ${target}
+
+          # TODO: make the overlay internals visible underneath its own mountpoint
+          # currently the mount fails with: 'mount: mounting /overlay on /mnt-root/overlay failed: Invalid argument'
+          # mkdir ${target}/overlay
+          # mount --move ${overlay.base} ${target}/overlay
+        fi
+        set +x
+      '';
+
+      services.getty.autologinUser = "root";
+      users.users.root.password = "root";
+    };
+  };
+}

--- a/modules/flake-parts/tfgrid-microvm/mk-zos-vm-dir.nix
+++ b/modules/flake-parts/tfgrid-microvm/mk-zos-vm-dir.nix
@@ -1,0 +1,39 @@
+{
+  self,
+  config,
+  pkgs,
+  bootFiles,
+}: let
+  pkgs2storeContents = map (x: {
+    object = x;
+    symlink = "none";
+  });
+  # trying to produce something that is compatible with
+  # https://github.com/threefoldtech/zos/blob/main/docs/manual/zmachine/zmachine.md#vm
+in
+  pkgs.callPackage (self + "/lib/make-system-directory.nix") {
+    contents = [
+      {
+        source = let
+          cmd = pkgs.runCommandNoCC "rootfs" {} ''
+            mkdir -p $out/boot
+            cp -r ${bootFiles}/* $out/boot/
+
+            ln -s ${config.system.build.toplevel}/init $out/init
+          '';
+        in "${cmd}/.";
+        target = "./";
+      }
+    ];
+
+    # Add init script to image
+    storeContents = pkgs2storeContents [
+      config.system.build.toplevel
+      pkgs.stdenvNoCC
+
+      # TODO: find out why `systemctl reboot dbus` is needed to make `nixos-rebuild` work
+      # these are also needed on the target for nixos-rebuild to work
+      # pkgs.path
+      # config.system.build.toplevel.drvPath
+    ];
+  }

--- a/modules/nixos/nomad-client.nix
+++ b/modules/nixos/nomad-client.nix
@@ -1,0 +1,219 @@
+{
+  self,
+  lib,
+  pkgs,
+  config,
+  ...
+}: let
+  nomadEnvDir = "/var/lib/nomad-env";
+  nomadEnvFile = "${nomadEnvDir}/nomad-extra.env";
+
+  cfg = config.holochain-infra.nomad-client;
+in {
+  options.holochain-infra.nomad-client = {
+    enable = lib.mkEnableOption "the holochain-infra nomad service";
+    machineType = lib.mkOption {
+      description = "machine type string that is exposed via the agent metadata";
+      type = lib.types.str;
+      default = "unknown";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    nixpkgs.config.allowUnfreePredicate = pkg:
+      builtins.elem (lib.getName pkg) [
+        "nomad"
+      ];
+
+    systemd.tmpfiles.rules = [
+      "d ${nomadEnvDir} 0750 root nomad -"
+    ];
+
+    systemd.services.nomad-env = {
+      enable = true;
+      path = [
+        pkgs.coreutils
+        pkgs.gawk
+        pkgs.jq
+        pkgs.iproute2
+        pkgs.diffutils
+        pkgs.nettools
+      ];
+      after = ["zerotierone.service"];
+      requiredBy = ["nomad.service"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        id
+        pwd
+        cat <<-EOF > ${nomadEnvFile}.new
+        {
+          "name": "$(hostname)",
+          "client": {
+            "meta": {
+              "FLAKE_URL": "${let inherit (self) sourceInfo; in sourceInfo.url or "unknown"}",
+              "FLAKE_REV": "${let inherit (self) sourceInfo; in sourceInfo.rev or (sourceInfo.dirtyRev or "unknown")}",
+            }
+          }
+        }
+        EOF
+        echo new result:
+        cat ${nomadEnvFile}.new
+        if ! diff ${nomadEnvFile} ${nomadEnvFile}.new; then
+          echo using new result
+          mv ${nomadEnvFile}.new ${nomadEnvFile}
+        else
+          rm ${nomadEnvFile}.new
+        fi
+      '';
+    };
+
+    systemd.services.nomad-env-restarter = {
+      enable = true;
+      serviceConfig.Type = "oneshot";
+      script = ''
+        systemctl restart --force --now nomad-env.service
+      '';
+    };
+
+    systemd.paths.nomad-env-watcher = {
+      enable = true;
+      requiredBy = ["nomad-env.service"];
+      pathConfig = {
+        PathChanged = [
+          # these files might change when zerotier restarts or makes connections
+          "/var/lib/zerotier-one/zerotier-one.pid"
+          "/proc/net/route"
+        ];
+        Unit = "nomad-env-restarter.service";
+      };
+    };
+
+    # sops.secrets.holochain-nomad-agent-ca = {
+    #   owner = config.users.users.nomad.name;
+    #   group = config.users.groups.nomad.name;
+    # };
+    # sops.secrets.holochain-global-nomad-client-cert = {
+    #   owner = config.users.users.nomad.name;
+    #   group = config.users.groups.nomad.name;
+    # };
+
+    sops.secrets.global-client-nomad-key = {
+      sopsFile = self + "/secrets/nomad/client/keys.yaml";
+      owner = config.users.users.nomad.name;
+      group = config.users.groups.nomad.name;
+    };
+
+    services.nomad = {
+      enable = true;
+      package = pkgs.nomad_1_6;
+      enableDocker = false;
+      dropPrivileges = false;
+
+      extraPackages = [
+        pkgs.coreutils
+        pkgs.nix
+        pkgs.bash
+        pkgs.gitFull
+        pkgs.cacert
+      ];
+
+      settings = {
+        server.enabled = false;
+
+        client = {
+          enabled = true;
+          server_join = {
+            retry_join = [
+              "infra.holochain.org"
+            ];
+            retry_interval = "60s";
+          };
+
+          node_class = "testing";
+
+          meta = {
+            inherit (pkgs.targetPlatform) system;
+
+            features = builtins.concatStringsSep "," [
+              "ipv4-nat"
+              "nix"
+              "nixos"
+              "holoport"
+            ];
+
+            machine_type = cfg.machineType;
+          };
+        };
+
+        tls = {
+          http = true;
+          rpc = true;
+          ca_file = self + "/secrets/nomad/admin/nomad-agent-ca.pem";
+          cert_file = self + "/secrets/nomad/client/global-client-nomad.pem";
+
+          key_file = config.sops.secrets.global-client-nomad-key.path;
+
+          verify_server_hostname = true;
+          verify_https_client = true;
+        };
+
+        plugin.raw_exec.config.enabled = true;
+      };
+
+      extraSettingsPaths = [nomadEnvFile];
+    };
+
+    systemd.services.nomad-reloader = {
+      enable = true;
+      serviceConfig.Type = "oneshot";
+      script = ''
+        systemctl reload-or-restart --force --now nomad.service
+      '';
+    };
+
+    systemd.paths.nomad-watcher = {
+      enable = true;
+      requires = ["nomad-env.service"];
+      requiredBy = ["nomad.service"];
+      pathConfig = {
+        PathChanged = nomadEnvFile;
+        Unit = "nomad-reloader.service";
+      };
+    };
+
+    users = {
+      users.nomad = {
+        isNormalUser = true;
+        isSystemUser = false;
+        group = config.users.groups.nomad.name;
+        home = config.services.nomad.settings.data_dir;
+        createHome = true;
+      };
+      groups.nomad = {};
+    };
+
+    systemd.services.nomad = {
+      serviceConfig = {
+        User = config.users.users.nomad.name;
+        Group = config.users.groups.nomad.name;
+      };
+    };
+
+    security.sudo.extraRules = [
+      # FIXME: the * causes syntax issues even though it's apparently supported by sudo
+      # {
+      #   users = ["nomad"];
+      #   commands = [
+      #     {
+      #       # this command will allow switching to any branch
+      #       command = "/run/current-system/sw/bin/nixos-rebuild --flake github:holochain/holochain-infra*";
+      #       options = ["NOPASSWD"];
+      #     }
+      #   ];
+      # }
+    ];
+  };
+}

--- a/secrets/nomad/admin/keys.yaml
+++ b/secrets/nomad/admin/keys.yaml
@@ -8,28 +8,37 @@ sops:
         - recipient: age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGTGV2dTQrVkFxUmNPelFr
-            Ums3UEFNVDl1OHJLcVYwTXJMaTRrbEJiREZBCk0xajVYaStaTHZwSDZsU00vMVFJ
-            c3NPVmdBcVhTcTVQRldad0lmV1NTQ0kKLS0tIHA4dkw3T0x5TzYxSVMzMlc5b1FL
-            MlpTQ3MzL29UTU1aM0VMR3NHTTBJODAKDYpsGHSJ5VdyFTVyW88cEH5a1LhM6klU
-            C4jHUPQSIeVev4T+zySdtozGNb+TEWLuhjJT6RwPILI814PL6OHhKA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvSFplZ1RYaEQ5SHlZckl5
+            eVhzLzQ2NExSQm9zb2VOcFplSmdZaE1GNVU0CnZiNGRoK2VhYWxPaTBwMmZTb2NV
+            Uyt1R0hLVllKUkFkL0dLc1RTSFl1cW8KLS0tIGZCS1daV3R1NloxQ2E5TnBQOGlF
+            cDdGSm5lVkFaSmwvazAycmFiMm1DcWcKYuPgFhsK63dE2uCL0ZxOCKPeNWPFihj7
+            8Lr2WYVfbi5O8bxGlrL7nQvQXau5XAup68RtK9Rnrfvdz2GsjOkBfg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArQjJzdHd5UHBBTStPckxj
+            OEFyaFZSSFk5bHU3RmxaYlpEZzBuNFVrOFhJCnAwTURObHNmOW5RWVdHUXdpMTJT
+            dVQyNDVrcUozOGprYW51eFlsQUs1ZXMKLS0tIFZ0RUNlV253dmROaHRQUEFFc2JB
+            K3I4SWE4dm5yUkZJdmt5amxPTzRrVWsK64BRiUHHuHBq5nrR8eCoK7DeLA1aCCzX
+            CkmtTsIYUYeE1ht1zuDR7Rz19zaL5KHxqhas9iQ411dVKtvQhvm9Pw==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2023-07-04T14:26:28Z"
     mac: ENC[AES256_GCM,data:fpzYyKWzwLs9sbRV04h2xyVw+4oZDewzf0C2WNt5RB+/ffy3dUrQotQJ8OHaVS4KboXHeJCT73ZRcVJcCFTs6smSPJXJLxsMkMbEarIlNTVFFp4OGplR62Ynr1/rivB7GlM8wyE51yKByHRQkecKI9ihI3eFdM4y3pkBCTdmrm0=,iv:TSW1Rlhem02fTrCB9CJCtml21Z/uEBAZEa30gzbGuxY=,tag:CraHtqFZbNKbBkAE6cvRMQ==,type:str]
     pgp:
-        - created_at: "2024-03-18T21:27:01Z"
+        - created_at: "2024-04-09T13:53:50Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcBMA0SHG/zF3227AQgAi1JSuHVKZZPqO+BNS+n25uIYZQZDznr8NIDz24UW066s
-            PhLm8IWpWLREiF6u410dn3zDCxQQ5kYqv+49nl/m4GMqif/BwueHhcATJlRZq9ll
-            wcIE5VkoyLKNFpAYW23oSEyfJ8cuakvmkzNXLw+sbljFWwUju9VKHz6Z55jBJalh
-            fWshg+yagzXKN6nOVGYDojJc/goaHUem2Iy9bD9SZGYPpDwV+/n9xk5wYV3FXeHj
-            4bGlgO8e5AzRts8BzBD8DyB7Ioed3rvo3uREmfRvJoJI3mlldH2EhInQbzBlASOs
-            F3aOwhnSx/N4+UGryEh3BUuao1aF/d6psFBndPRCJNJRAYU8S3HT01mrOgk52Mww
-            pLaeCU1E0g9NHkW/PruJcitvhZW4i/JzH8Qq+G1iUUJ3EdfnzxeQawZtOB1rPwlj
-            0MrRvz4Ext4O//6Px3mDK0Ja
-            =WarA
+            hQEMA0SHG/zF3227AQf7B/bqwwcbfJ7TUKiabfYcae4fqPkj2Gs221FsmtmHIYBU
+            5oE2dmr4xDyjIGR6agUcJ47ZHPI4ZYYnuTMY2zUPkzKOcmwOOOc/RgaAw71sWQe0
+            +8UkTS898iJVUNK45cgk4/OS+oA90YurgXSMNTz0hbe2iPspDPK6nakNU6+/IvRs
+            lO2bsSLzF4NuxAd1xk98teyVQeeuVPeBkG1SfbOVzwQRh+Yv7erI0hUHoRAZJam4
+            1c4g/+uH5REf63zT9wOlsGU/rrabaFnj/sONjEAixqhmfAKRD2iOcekIg3iArkDG
+            LXdClAkRqi644T2uoiZ6mS38w3PrZUV0qv0orcYgDtJeAVeaHU0kFXr5D6afIgPE
+            3HFgdhjdLhkrfxDnihSo1+K43ChnKn1zKnCYN7VCiI5GjSMfy9jeuinV4XJ4Rtks
+            ko+YdYV9DRDCNu1kxUfdUVIlgPBaogjIfwCJMotf/Q==
+            =0Hil
             -----END PGP MESSAGE-----
           fp: 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
     unencrypted_suffix: _unencrypted

--- a/secrets/nomad/cli/keys.yaml
+++ b/secrets/nomad/cli/keys.yaml
@@ -8,28 +8,37 @@ sops:
         - recipient: age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCSG1YZHAvOU5kQmR4aklh
-            a0FPdHdaOTljMlBBNGtiWHo4Vmd1T0llVzBvCm8ybGl5VzhnM0QrNW1ZS0tqdG9s
-            Z2E3ZU9MUHFJWFlIN1ZsazhCTnVoWkUKLS0tIE9HTktCY3hEcm05QUVSQTlFSWQ5
-            ajVOa3REbmpEZHNjbkFQa0NIS05sV1UKmB6F8oW9w2tC+EaWoYCnLkHIfqL1idk6
-            jtce1k+htxaQhXe78wEugGMRONb++QDqIz+bNjLe8HZrEJZ79yIm3g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFS1k3Q1J2YXk4NFphQmE0
+            Wko3REVHWWVxNmxBNmtrNnFIN0VjeTFRczFzClhwdEp6azhiWkFUQk5oejBDbElG
+            YjB5WDhEVWlya2xmaUcranA4by9yVW8KLS0tIG5STVl5dndNTXZPY21nN25LQWl4
+            VVZFRGhHN0wzUERtN0s5NkdYUDIxVEEKAV4A5rJ10JffhC6K99TwcfamJboMVP57
+            e7PKiSvgAqwiXgsRPs/o1yuCRfzpysY4qwdjOJNXgon/3GLPSQlSsQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLQ3QyRmJjVVp5d1dNL1U2
+            ZDBhc21uWEdRWC80TVRVTXhGT1VNZllFNUZJCmdyNEUzTnRpZkVPRlFOODkyNkxW
+            Zkh1dm9rZnVNUnRjb3EwUHVuSnlkd2sKLS0tIDl1aDZFZ1k2U1lYVlhhM2pXZ0Fx
+            aGticEpJR0ZXWmhqTEZKUjNZdXhYdzAKorn9V0rjpX3volhfsX2vMalURlD1dzY5
+            Ztakrib6lu2WrNI7wKTyKJmGjysczN7nAzCMj/md3oZ7zou+P8v1sA==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2023-07-05T09:14:30Z"
     mac: ENC[AES256_GCM,data:xASypo/4Hfyz4118WUKcork3KtbOhsYR1haK4BfncedCxjNfAf9F+D1gfpUD/TRhT3tf6ZTelHc8l9T/FXnK/Ur0IGoIubS7NMOHPQncB1WpOCusiHIlIHqOAqlEhNrzT/8Kct2HEXe8yGs/WgWHuzEkEfRupnME3dml0FJnZXw=,iv:HTYK/ayED0LRZH2Gp53YsfpeXdgYG8PwKZ6H0ddCcLA=,tag:1UniA+s1b5QsRHSnLBIOCQ==,type:str]
     pgp:
-        - created_at: "2024-03-18T21:27:03Z"
+        - created_at: "2024-04-09T13:53:51Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcBMA0SHG/zF3227AQf/aNPG9i/s+tcVEu6jJ6y5vCM8qC7T5JfL1i3ITMzJxPSP
-            Y86F42DdojMp6Rxkz7JvIwgyo7apmg3um/NlKZ5BYi5wicv7vmj46D9YJmuB6W2v
-            8QJy/dezwmFQPyvbKwfUjRbCc3U5mWhhROmWQiWNJ1l74Hpfac84BOIPvLEWlkJf
-            ZmvUmrAM/K9YxXoQiYVZn+HPHsCVFR/sMgSAR+Qfgobg+IiQp+EED/WuC4G2jS8V
-            CCfEKFNXbzc37F7CpZyHuW3ePZpcGMemU8YphDYJ+/tcw5ch0o+pcFr2araLsSL3
-            Cmvo2loPsKO2xBJTyJQR7LVTkafPRjMzoI5L5r5ncNJRAYUtwvAVeofohoB8YCms
-            HwDZLE0wwpSDBOj1E169xIzGgwg/wy5UtlP95YDxg8WkVN3kjkxVF/dnFBg1uaCw
-            vyvDTvaG5KOdCEnEXtiB5Ccr
-            =t67I
+            hQEMA0SHG/zF3227AQgAkQ7kdUexYobw+Kz64W5Z8YjGam3sPgyRtUFX3hHoBt6T
+            CyQx+7hVZM8ZPP9BhdtJUVkf6ygAksOb+SrYQVUqZ2fcK3PyPm8X0gARKupRXE/8
+            FE1KVCHE9U8JH/mJZQO4VYZWNZXt3KzWMMqVmFC4ZhF9P6twAyeRNJw6grXL9dHu
+            q4y57H3XndPppJFTVtEz4kmNU2gevGzVEJhPxhTcSzcLnWZ2iXu9Z0Fe4gv1zbhz
+            /5zLdMU9EDq2hOzU9mP5dmyvEb40qMTfZb24geUfWItO3IpqsIbwD03ECBk3oX8t
+            NRQofBQYsFEy52x0oB6WBHvRt719qP22LBpCIzecodJcAd60Fay7q7xjgtS7rLeA
+            Z+mfdnp7dItwhTUAQSySWiRNL9IFdhJCyQYNqij5QnvzZ/tCRxofh+DGfQHtmEG7
+            S1qSi8aCAK7vvHWw5OO+BOAGUSbgpRTwDXM2VWM=
+            =o+qC
             -----END PGP MESSAGE-----
           fp: 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
     unencrypted_suffix: _unencrypted

--- a/secrets/nomad/client/keys.yaml
+++ b/secrets/nomad/client/keys.yaml
@@ -8,28 +8,37 @@ sops:
         - recipient: age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1U0MybVJqdzZxSG1TSHQ0
-            RVpWbk8wUXlORXhya1duQUNwSThhUXFjcmg0CjErODhFMjNEaDl1V09hb254U05o
-            WnpFNVNpdWd1UFA3emFITHNjd0JrVTAKLS0tIGprYjN0K3hHcWd5dGpsbmNpVGxk
-            aEhRYlVHQnNpUGs3cExYRjNheURKZEEKuONf6KQptwKPfpjoq6NE6pql7hRTmBEa
-            jWlskL212zPKy4jwBTILVxpSECYgWuyGmpUCVhgduXP8HPOtjUuEVA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWNU9BUnIwcnNpb2RlL2Jv
+            MTdCb29DakRqcVN5VEE0dDZCL0hYbmtaVVhRCjk0bnJ1SHJxbEpBQUdvZTJyb1BN
+            Z0k4T0N5VjJSM1pkTkZIVFdKRm5DbzgKLS0tIHppWlJ5M1VYUGltaUh6UWRRc2ZI
+            bDlZNnE2QUQvNXRaMUlxbFJ5RzRDblEKfZvZXSo2Qqzi8CwF2q1LIkbTxIsFrGU3
+            pK59wDkLu3EIlgo9jQM+WZFNrw8AaARX6PKMbYAMMp0EzoBdySCW1w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBieGRaYWdZMXlvNjFUQmJm
+            OS9XL1F1UVphdGVtaFdPYWFWdFpwM1EyTnhnCjRGSUNEN1JDTU1VUWVWWitudDht
+            L0srVzRTQ3M3TXJ3UEFkajhXRXpmQmMKLS0tIDFyc2ljdm9xazJXZU9tbVRGWk04
+            WmJqV1NablU3Z2NpY0V2UnUzOEtFemcKIi2jsCBjft23TRcq8nfdbdLyb+d5RQuY
+            LhQcR3Dy9WvDkRkIwrv4y9ZCACOO9IB53WR8sIh/zHaf+4HGoVnM/Q==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2023-07-12T09:25:18Z"
     mac: ENC[AES256_GCM,data:tQR1UYHFm8YnjcXqGLJaPz6X5SaTrlQ913KjS6waFz/LUEYzGfmAjqjJEH+/xRupS2daNxvTrpmNk5j8QTMFlDSUaKgse3dqQucL7dpJ6dE8PSGolXayswDw54kb8yNXi1u6JRg3v/5lyVrj2zajAmyFkYeila9TrwlZVwh8drA=,iv:cJ/561WeaYcW7Zrv50c79JPlWaY7iGQxlEr/17+tqh0=,tag:sH8gnl69GjJbe7eAbPbuwQ==,type:str]
     pgp:
-        - created_at: "2024-03-18T21:27:04Z"
+        - created_at: "2024-04-09T13:53:51Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcBMA0SHG/zF3227AQf+Oq7+G/LBsGNtyOmLWuDUv5mLQ4IjiOWO02w6/AgmKzAs
-            6nKLwSY2v56pezR8TaDO7U2GtSLhqJihcM9zaHpBtfEc6tKQ9jJEh8RLiT6MWuPv
-            vjQ8BljqMJ4Y3DzoOuO2h4/Y0F9XuNgaiSoicf4Vs4F8NYjuBmnxdilhO1199jfx
-            oUu1s38yDEtfgHSLtjDrxrT975jrnqFeaTh2t+qClHZ23fRYi5bqVw6TxizJL0Ma
-            eAXAW/Ujj6MeBe2dLB3icj5lj+nbedO6AM6e4lM3JkMWY9z8eke+XetRQqyZYY/0
-            C9M4PZ5NAB295ldPjOAZzY9PtWoWQB/C7wOkXgWm69JRAdHZSre0jWRGsq5oMe1P
-            9ROIcCh5DEnYuHhlFk4Hssk+ZNniC3z/0+lF+z8A0/OusMkUcCSDGCG3XO0loCPN
-            eGtY2qA3xRFEOabr/cfGLSUQ
-            =lC6i
+            hQEMA0SHG/zF3227AQf+P5TrwLAC9W2TYXOfsiG8pySSVTD0edVrhUTLaBdMzrlx
+            UlZYQs2Eg2XxNBSle2Dq2TIKkd26bOszzptU+dApPJOyXpltmYDm5xgYPKWq/VuV
+            gqNC4rAetP0m2OUqb/Qevbm777zLuaVqGyYbO/4FDFdSRsWaW48OHzbk/1dHbIRI
+            wDEoBRyAnrS23QzDnajsDMTYUXEddoS5QmFbTRsYvSBMvQ4jKAxYDxQVbEhYGVcW
+            7INydzITdt6s3kmToFic0rKl+dzFYQSj5tdTHgQPQPgigtRJh6i60zDIr3yuuyD0
+            paD22nw1XTyUH+SJrSFM+FYJNjlWpujoJVpYytD879JeAVReI+sqV6cWvgYQC8yz
+            dzuziG/h6pXrfBTReiFdXjafQp8qtiCw8CVv9R96/qAAIqv9pxpyhV3pfsuMgRxd
+            2VaHP3QDNvkZhszwOBAyzWJEPLSIL5sS6IIkjznRIg==
+            =z72P
             -----END PGP MESSAGE-----
           fp: 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
     unencrypted_suffix: _unencrypted

--- a/secrets/nomad/servers/keys.yaml
+++ b/secrets/nomad/servers/keys.yaml
@@ -8,28 +8,37 @@ sops:
         - recipient: age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5QkFMRDE2MEFTRXJLc0lT
-            Nkd5YmpIbzl5dCsvSEZmczZIcVljYzV5WkVzCk1UUGE1c2JRWFhQZVRQQ0prYk5m
-            NVA3TFJuRXRxMUZheVdMMmp1RWt4NU0KLS0tIHFmb05CNERHVGRlZ2pvVCtNeE9v
-            Q1A3OFFLbm5XekhOaWdHR0xGanBLU1EKDzNqlIBK+Si1DfvgbmQlJh/ubumYYEAx
-            xzVaulVhfq6TWgkcpS6zwFLcNS1qzeDNLKwmd2RlJ8iQpgafdiGHSw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1V1l6c2tUdUdUU2VLZXVs
+            QUZqSGx1emtkU1dNcVp1TENoN1RJVlltS2xBCjFDQzZSVUkxUSttc3lkQXJsbkNm
+            NXpYZlpabmt5eVcwb294b3pXcmxPTlUKLS0tIE9mb1NFRWsrS0U5WjJweVc2bkZG
+            bTZIN3UyNjEraDh2Q3gwVzducEtqejgK22brmzSCK/vejuRjywMoS0LNeR7vSFRQ
+            5yri45yyjvj96SEpn+Gwx6q7q8SkprnUXI9HlYSfXX/KH+x9shCVQA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2NmowQ1cwQlY4SUUrRklw
+            dmpvYXFlUXB6UC9KNHc4SjdOY2dSM0p4WUI4CnN4dlFjSnN5YlAwKzJLWC9OZVJG
+            aU9uVVh5T3pCZVJqdHBOakQ2dCs2T2MKLS0tIENRd1hBN1NhbGJTaE8wMGcrQzhI
+            V3FHM1lQelJ0Q3YwMVZiMGNUbjYxeEUKZW1sN+kxDExMV3SXRDgkOrOEGshT+xky
+            pFD3d/9zx4yF1Xz1wqi2XONGXQbczqRw91c7hHFTtUlmi4notWfn9Q==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2023-07-05T09:59:44Z"
     mac: ENC[AES256_GCM,data:qKRGsoInfFTGoJj59ecQV8bwakcwBLK20rBmqRlNuNGr/KeBGSf4d1gbBiJf5Uk5VJZuZJGyhpGvFlzeB20vhwVvMHEUl6g4nr+sft2ZskXWfM02+4pq2dA2T4lQOhix2Hmr8vLqbdoKMcxT73CwsLBxduAJ1DIOG+Q617LFGa4=,iv:C6D2tNlbmgfSuIJeZZSRygT/pWWPw95LNAGN9oBljdE=,tag:/chzfo0NBAlgkGJTvSqYGg==,type:str]
     pgp:
-        - created_at: "2024-03-18T21:27:06Z"
+        - created_at: "2024-04-09T13:53:51Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcBMA0SHG/zF3227AQf/cLdA/l1SnxJO9lnmd15lQUjHndRH721N2hWAFTVFndin
-            6nq71PYZwfdubyZ6npVjzZzCwI0Jrh0A2Tn4lYXoEGVFDEg/Z5DU9FXwxHQaF4IV
-            50y1FEybvR+5FHNQHtyor2pQ+56E2bNte06/peAnDh2PxZpdJsmMmSZ8+15CeOxA
-            UcUc00rWjPuHJE+CJtwKZ+C5LE3ypFehsF6s1ZQqlK/hd+MI0ROdfm+tloAAZ2fV
-            04Ie4IP2gfjw/4ie5vDQT99AolKycL5goRzAyOEmvPLJRhl0TRR3mlZ9vJsgnJm7
-            aibcPB8q8vzluCxHpQY+e1ccqlPoeP6xVXBOtOOCjtJRARXFF0tK/+il4bAyhOwa
-            Cfit7jodFmo1QSTQo5DJXs7SrmV7Sm8sj40HEiuTqy0H64L31PCJV42Ttcm9/iHI
-            rKw+PYINnmufCDVk5j5P/8Bp
-            =uIWo
+            hQEMA0SHG/zF3227AQgAoPliVVfOXGsH7CQGdF47rZNtwblYgsn4mZ1xv49Hf8K+
+            rIocy9cWXvb1qy+6UYbBJkWIH4vFlhEHGpM41dyOlDBku7wZCCy0aFPWOz+RnqOT
+            32QolWYhEPT30E5PkQA0uzY9FSTky2Y6Qp6J100E29zseJK2CE77nzUmDeUbKHAS
+            z6HRkEolutnOELHzEpLTsHhrT1VsH1FCSMbUTZpOPS/zJKsyDmY0HbLCI5gpBU2i
+            C/RAvHrerhnrxrhE8cAbfWrr5TIYiMnUJe63t40OnFydaK80E2CHStDkJDGqlCcc
+            zQQWzVAd1Vm9PcNrpWNLJ+hfTgcB3NhhRX4dY4tDEdJcAekfg4wIPH8XpXCjzt6K
+            c/5/i4mFObflCAyvFEMAgXuekrR1rqUvDxqBxItXW4TbGl7QIT2n1xDg24l1ACRQ
+            RDG/rt6bYpIOLdsqSt9uRqJMzG8c3W1webKPOQc=
+            =GHU/
             -----END PGP MESSAGE-----
           fp: 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
     unencrypted_suffix: _unencrypted

--- a/secrets/static-age-keys.yaml
+++ b/secrets/static-age-keys.yaml
@@ -1,0 +1,27 @@
+tfgrid-shared: ENC[AES256_GCM,data:B9m8IUZY9T1q4U8vB+U+sAgO2i8juYwyujZ/ADlOKFBPg/c4YjBDhGi5W+R2ZE+l+x6ilUdjJ/T1K8jXpj/oqEarX3eMC3BVv58X5Y9EZygIJ1AoU90BQ/caOUSduW8Gfo2rv+S+TEhpWqPr6urSPwUbZxRWPfUPAOmMRlYfmP8RIEuK13gMLqNX+CSWW47a3kqUF7YzPXr3AXIsws04SU57P3Cvggxgk5qKqMmJloJqbPxU6e20dahEc2sN,iv:vVcyScJu2aWLW+ZDWqTOGKrGQowQDC6c9UD2ADdFNXo=,tag:K8w91hyNqtlLvergYIrdiQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-04-08T19:23:50Z"
+    mac: ENC[AES256_GCM,data:nwFZzHjCbCEI6+83tOA+dR3eENr0+XKrdCt1+QkZAAcYr3GmPI6LFU+Fg9VIuTdai05B1IMayxxFigWfKWCzYA41XlostTH0P3AKfN3+0S9t+JHBFkwznIIWpOwOzELbTPuUkX2LTchwcLXi5JaL3lxhZz466bFZQzZEACjO9rE=,iv:xmj+ggupykmnikg7VOwPFsBkA0euY4Pp4rKGQdemsgI=,tag:pdKpJCFsH2ev8NAhN1MBvw==,type:str]
+    pgp:
+        - created_at: "2024-04-08T19:23:17Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA0SHG/zF3227AQf+JVOCY4jcQF+WXDDhm8HB7kbHNAK00qehk9gdm52krgMZ
+            FtS0OSSlS7leBsDffNf6GIcvBh0pFZ/thFaQI5FASxHjVKAI84uUCZzbaPpF7h1k
+            xSuNhZnEjyoTESJ0IYIVP6cTtdZAiN4g1wjennvnfOzikGLOqt41GWssYc5qcjkB
+            /rhnVRDVeiAa+X9v/7aEopWxl2kzx6B+56hiBexNdSccjYpTzfdokf8HhAEJNwPL
+            nAdhla7Q1EPoyGoepoHdRkfRNYMv5fcdRB5cpD3JXUO0cMq2uoEzX/ZQvsSe6oIz
+            lu7fZtwgvbxzywQzK5SdwZwKeHkWXur4Le5hLw9NutJeAU9AJQVvxoixglYcsyLv
+            HeBXwGnocvwRmL8L/CasNBRVv1DTT29ZEgylrzMj1oSEx8DC9APg437r8GzZgIfh
+            n/v7N2lXJFUjU7r/5XOgvirV4BVjJGSyjS01lA9M9Q==
+            =+372
+            -----END PGP MESSAGE-----
+          fp: 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
nixosModule.zosVmDir add `config.system.build.zosVmDir` which results
  in a directory that contains a rootfs, (uncompressed) kernel and
  initramfs. the resulting file structure can either be booted using
  virtiofsd + cloud-hypervisor or published to an s3 endpoint for
  consumption on tfgrid

zos-vm-*: scripts to build, publish and local-boot zos microvm system images

try to get nixos-rebuild working in the VM

tfgrid-devnet-vm0: add iperf3 and man

experiment with grub

make bootloader install a noop

nixos insists on having some bootloader but we don't need one for zos microvms

secrets(nomad): add tfgrid-devnet-vm0

feat(secrets): re-encrypt nomad keys

feat(nixos/modules): add nomad-client

feat(tfgrid-devnet-vm0): enable nomad-client

try out external bootloader hook

feat: add initial nixos-rebuild-helper

  mostly for dev work as of now; may be removed or refactored into a
  system service later

feat(flake): bump rfs

feat(tfgrid): split into base and devnet-vm0 profiles and install kernel/initrd to rootfs

feat(tfgrid-devnet-vm0/sops): add age.key path and pregeneated age key