### PR TITLE
feat: introduce nixpkgsNix, set nix version to 2.20; chore: bump nix-darwin and fix darwin deploy script

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692613703,
-        "narHash": "sha256-ByFRYQ8J4YSeAU6N0gUc5nmIjAGoiDU+jMUL73Ns0ZU=",
+        "lastModified": 1715935620,
+        "narHash": "sha256-b60zHhqS67LW9nTxl7p6ba2OdXJAMoMclEYHbRPpwKM=",
         "owner": "steveeJ-forks",
         "repo": "nix-darwin",
-        "rev": "72d647c8bda6d8d8a88ba2b63b56ce4e0be57ea7",
+        "rev": "9f51e374d7cc7fdf7c9b2578a5757b92d028e2ea",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -542,16 +542,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1685599623,
-        "narHash": "sha256-Tob4CMOVHue0D3RzguDBCtUmX5ji2PsdbQDbIOIKvsc=",
+        "lastModified": 1715381426,
+        "narHash": "sha256-wPuqrAQGdv3ISs74nJfGb+Yprm23U/rFpcHFFNWgM94=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93db05480c0c0f30382d3e80779e8386dcb4f9dd",
+        "rev": "ab5542e9dbd13d0100f8baae2bc2d68af901f4b4",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -977,6 +977,22 @@
         "type": "github"
       }
     },
+    "nixpkgsNix": {
+      "locked": {
+        "lastModified": 1715787315,
+        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgsUnstable": {
       "locked": {
         "lastModified": 1690179384,
@@ -1108,6 +1124,7 @@
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgsGithubActionRunners": "nixpkgsGithubActionRunners",
         "nixpkgsMaster": "nixpkgsMaster",
+        "nixpkgsNix": "nixpkgsNix",
         "nixpkgsUnstable": "nixpkgsUnstable",
         "sops-nix": "sops-nix",
         "srvos": "srvos",

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
     darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     # home manager
-    home-manager.url = "github:nix-community/home-manager/release-23.05";
+    home-manager.url = "github:nix-community/home-manager/release-23.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     # secret management

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.follows = "nixpkgs-23-11";
     nixpkgs-23-11 = {url = "github:nixos/nixpkgs/nixos-23.11";};
+    nixpkgsNix = {url = "github:nixos/nixpkgs/nixos-unstable";};
     nixpkgsGithubActionRunners = {url = "github:nixos/nixpkgs/nixos-unstable";};
     nixpkgsUnstable = {url = "github:nixos/nixpkgs/nixos-unstable";};
     nixpkgsMaster = {url = "github:nixos/nixpkgs/master";};

--- a/modules/flake-parts/apps.deploy-/darwin.nix
+++ b/modules/flake-parts/apps.deploy-/darwin.nix
@@ -18,17 +18,17 @@
         ])}:$PATH"
         set -x
 
-        rsync -r --delete ${self}/ ${deployUser}@${hostName}:/tmp/deploy-flake
+        rsync -r --delete ${self}/ ${deployUser}@${hostName}:/private/tmp/deploy-flake
 
         ssh ${deployUser}@${hostName} /nix/var/nix/profiles/default/bin/nix \
           --extra-experimental-features '"flakes nix-command"' \
           build \
-            -o /tmp/next-system \
-            /tmp/deploy-flake#darwinConfigurations.'"${attrName}"'.system
+            -o /private/tmp/next-system \
+            /private/tmp/deploy-flake#darwinConfigurations.'"${attrName}"'.system
 
-        ssh ${deployUser}@${hostName} /tmp/next-system/sw/bin/darwin-rebuild \
+        ssh ${deployUser}@${hostName} /private/tmp/next-system/sw/bin/darwin-rebuild \
           -j4 \
-          "''${1:-switch}" --flake /tmp/deploy-flake#'"${attrName}"'
+          "''${1:-switch}" --flake /private/tmp/deploy-flake#'"${attrName}"'
       '';
 
     mkDarwinDeployApp = attrName: config:

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -1,5 +1,5 @@
 {
-  self,
+  inputs,
   config,
   pkgs,
   lib,
@@ -17,7 +17,7 @@
     # ]
     ;
 
-  nix.package = lib.mkDefault self.inputs.nixpkgsNix.legacyPackages.${pkgs.stdenv.system}.nixVersions.nix_2_20;
+  nix.package = lib.mkDefault inputs.nixpkgsNix.legacyPackages.${pkgs.stdenv.system}.nixVersions.nix_2_20;
 
   nix.settings.extra-platforms =
     lib.mkIf pkgs.stdenv.isDarwin ["x86_64-darwin" "aarch64-darwin"];

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -1,4 +1,5 @@
 {
+  self,
   config,
   pkgs,
   lib,
@@ -16,7 +17,7 @@
     # ]
     ;
 
-  nix.package = lib.mkDefault pkgs.nixVersions.nix_2_18;
+  nix.package = lib.mkDefault self.inputs.nixpkgsNix.legacyPackages.${pkgs.stdenv.system}.nixVersions.nix_2_20;
 
   nix.settings.extra-platforms =
     lib.mkIf pkgs.stdenv.isDarwin ["x86_64-darwin" "aarch64-darwin"];


### PR DESCRIPTION
deployed to 
- [x] linux-builder-01
- [x] ~~macos-01~~ currently broken
- [x] macos-03:[^1]
- [x] macos-06: [^1]
- [x] macos-02 [^2]
- [x] macos-05 [^2]

postponing due to unavailability:
- macos-04: cannot login: ssh is asking for a password. tracking in  #97

postponing these until #68 is resolved. these are not involved with the holochain CI nix builds, thus they only need nix to build their own system derivation.
- dweb-reverse-tls-proxy
- turn-0
- turn-1
- turn-2
- turn-3

potentially fixes https://github.com/holochain/holochain/issues/3556.

[^1]: could only get to 2.19 at first as 2.20 would show: `error: 'show-config' is a deprecated alias for 'config show'`. was held back by the lack of #91 until i rebased that in [11db2c4](https://github.com/holochain/holochain-infra/pull/92/commits/11db2c457339209ab50021955386ebb537e3fc7f).
[^2]: @peeech @alastairong any contraindications for deploying this on our shared darwin machines?
