### PR TITLE
feat: extend holochain-turn-server module and add stun-0.main.infra.holo.host instance

### DIFF
--- a/modules/flake-parts/holochain-turn-server.nix
+++ b/modules/flake-parts/holochain-turn-server.nix
@@ -86,6 +86,12 @@
           type = lib.types.attrs;
           default = {};
         };
+
+        extraCoturnConfig = lib.mkOption {
+          description = "extra config passed to coturn";
+          type = lib.types.str;
+          default = "";
+        };
       };
 
       config = lib.mkIf cfg.enable {
@@ -137,7 +143,8 @@
               ''
               + lib.strings.optionalString (cfg.acme-redirect != null) ''
                 acme-redirect=${cfg.acme-redirect}
-              '';
+              ''
+              + cfg.extraCoturnConfig;
           }
           // cfg.extraCoturnAttrs;
 

--- a/modules/flake-parts/holochain-turn-server.nix
+++ b/modules/flake-parts/holochain-turn-server.nix
@@ -78,14 +78,14 @@
 
         username = lib.mkOption {
           description = "user for establishing turn connections to coturn";
-          type = lib.types.str;
-          default = "test";
+          type = lib.types.nullOr lib.types.str;
+          default = null;
         };
 
         credential = lib.mkOption {
           description = "credential for establishing turn connections to coturn";
-          type = lib.types.str;
-          default = "test";
+          type = lib.types.nullOr lib.types.str;
+          default = null;
         };
 
         extraCoturnAttrs = lib.mkOption {
@@ -140,7 +140,7 @@
             enable = true;
             tls-listening-port = 443;
             listening-ips = [cfg.address];
-            lt-cred-mech = true; # Use long-term credential mechanism.
+            lt-cred-mech = cfg.username != null && cfg.credential != null; # Use long-term credential mechanism.
             realm = cfg.url;
             cert = "${cfg.turn-cert-dir}/fullchain.pem";
             pkey = "${cfg.turn-cert-dir}/key.pem";
@@ -153,8 +153,10 @@
                 no-multicast-peers
                 no-tlsv1
                 no-tlsv1_1
-                user=${cfg.username}:${cfg.credential}
                 prometheus
+              ''
+              + lib.strings.optionalString config.services.coturn.lt-cred-mech ''
+                user=${cfg.username}:${cfg.credential}
               ''
               + lib.strings.optionalString cfg.verbose ''
                 verbose

--- a/modules/flake-parts/nixosConfigurations.stun-0.main.infra.holo.host/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.stun-0.main.infra.holo.host/configuration.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  ...
+}: let
+  # https://console.hetzner.cloud/projects/1982619/servers/47741841/overview
+  hostName = "stun-0";
+  domain = "main.infra.holo.host";
+  ipv4 = "37.27.39.142";
+  fqdn = "${config.networking.hostName}.${config.networking.domain}";
+in {
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.mixins-terminfo
+    inputs.srvos.nixosModules.hardware-hetzner-cloud
+    self.nixosModules.hardware-hetzner-cloud-ccx
+
+    inputs.sops-nix.nixosModules.sops
+
+    self.nixosModules.holo-users
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+
+    self.nixosModules.holochain-turn-server
+  ];
+
+  networking = {inherit hostName domain;};
+
+  hostName = ipv4;
+
+  nix.settings.max-jobs = 8;
+
+  nix.settings.substituters = [
+    "https://holochain-ci.cachix.org"
+  ];
+
+  nix.settings.trusted-public-keys = [
+    "holochain-ci.cachix.org-3:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8="
+  ];
+
+  system.stateVersion = "23.11";
+
+  services.holochain-turn-server = {
+    enable = true;
+    url = fqdn;
+    address = ipv4;
+    listening-port = null;
+    nginx-http-port = 80;
+    verbose = false;
+    extraCoturnAttrs = {
+      cli-ip = "127.0.0.1";
+      cli-password = "$5$4c2b9a49c5e013ae$14f901c5f36d4c8d5cf0c7383ecb0f26b052134293152bd1191412641a20ddf5";
+    };
+    extraCoturnConfig = ''
+      stun-only
+    '';
+    acme-staging = false;
+  };
+}

--- a/modules/flake-parts/nixosConfigurations.stun-0.main.infra.holo.host/default.nix
+++ b/modules/flake-parts/nixosConfigurations.stun-0.main.infra.holo.host/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.stun-0_main_infra_holo_host = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}


### PR DESCRIPTION
fixes https://github.com/holochain/holochain/issues/3479.

- [x] deploy to `stun-0.main.infra.holo.host`.
- [x] added alias URL `stun-1.main.infra.holo.host`
- [x] test deployed instance using `hc_service_check`

follow-up:
- [ ] set up monitoring and alerting for `stun-0.main.infra.holo.host`