### PR TITLE
feat(ci/pr): build OS configurations

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,9 +17,9 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: DeterminateSystems/nix-installer-action@v12
+      - uses: DeterminateSystems/magic-nix-cache-action@v7
+      - uses: DeterminateSystems/flake-checker-action@v8
       - run: |
           nix build .#build-os-configurations
           ls -lha result/

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   pull_request:
   push:
@@ -5,12 +7,12 @@ on:
 
 
 jobs:
-  os-configurations:
+  os:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-13]
-    name: OS configurations
+    name: OS
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: "write"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,17 +3,23 @@ on:
   push:
     branches: [develop]
 
+
 jobs:
-  lints:
-    name: Build
-    runs-on: ubuntu-22.04
+  os-configurations:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-13]
+    name: OS configurations
+    runs-on: ${{ matrix.os }}
     permissions:
       id-token: "write"
       contents: "read"
     steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@main
-    - uses: DeterminateSystems/magic-nix-cache-action@main
-    - uses: DeterminateSystems/flake-checker-action@main
-    # - name: Run `nix build`
-    #   run: nix build .
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - run: |
+          nix build .#build-os-configurations
+          ls -lha result/

--- a/flake.lock
+++ b/flake.lock
@@ -679,7 +679,7 @@
         "versions": "versions"
       },
       "locked": {
-        "narHash": "sha256-eczsmDRDhXlN6GQ5h0UBWsDe5hKnthl//O3hiC1+JnY=",
+        "narHash": "sha256-EwKzTn3/LhIFtaflp4X96RUcAIyJKzftSfUM+vz6wCk=",
         "type": "tarball",
         "url": "https://hydra.holo.host/channel/custom/holo-nixpkgs/2112/holo-nixpkgs/nixexprs.tar.xz"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -1305,6 +1305,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-24-05": {
+      "locked": {
+        "lastModified": 1718086528,
+        "narHash": "sha256-hoB7B7oPgypePz16cKWawPfhVvMSXj4G/qLsfFuhFjw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "47b604b07d1e8146d5398b42d3306fdebd343986",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
@@ -1435,22 +1451,6 @@
       "original": {
         "owner": "nixos",
         "ref": "master",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgsNix": {
-      "locked": {
-        "lastModified": 1715787315,
-        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1683,9 +1683,12 @@
           "nixpkgs-23-11"
         ],
         "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-24-05": "nixpkgs-24-05",
         "nixpkgsGithubActionRunners": "nixpkgsGithubActionRunners",
         "nixpkgsMaster": "nixpkgsMaster",
-        "nixpkgsNix": "nixpkgsNix",
+        "nixpkgsNix": [
+          "nixpkgs-24-05"
+        ],
         "nixpkgsPulumi": "nixpkgsPulumi",
         "nixpkgsUnstable": "nixpkgsUnstable",
         "sbd": "sbd",

--- a/flake.lock
+++ b/flake.lock
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692613703,
-        "narHash": "sha256-ByFRYQ8J4YSeAU6N0gUc5nmIjAGoiDU+jMUL73Ns0ZU=",
+        "lastModified": 1715935620,
+        "narHash": "sha256-b60zHhqS67LW9nTxl7p6ba2OdXJAMoMclEYHbRPpwKM=",
         "owner": "steveeJ-forks",
         "repo": "nix-darwin",
-        "rev": "72d647c8bda6d8d8a88ba2b63b56ce4e0be57ea7",
+        "rev": "9f51e374d7cc7fdf7c9b2578a5757b92d028e2ea",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -947,7 +947,7 @@
     "keys_thetasinner": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-8RWZCPJpXCWx9vwVoimLJG0YQzXow9bexgUnyb9T5Hs=",
+        "narHash": "sha256-sDa25rA0Qb8ASDLWBXQ3YIDVwDoK56cgQGow+3aWNfE=",
         "type": "file",
         "url": "https://github.com/ThetaSinner.keys"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,8 @@
   inputs = {
     nixpkgs.follows = "nixpkgs-23-11";
     nixpkgs-23-11 = {url = "github:nixos/nixpkgs/nixos-23.11";};
-    nixpkgsNix = {url = "github:nixos/nixpkgs/nixos-unstable";};
+    nixpkgs-24-05 = {url = "github:nixos/nixpkgs/nixos-24.05";};
+    nixpkgsNix.follows = "nixpkgs-24-05";
     nixpkgsGithubActionRunners = {url = "github:nixos/nixpkgs/nixos-unstable";};
     nixpkgsUnstable = {url = "github:nixos/nixpkgs/nixos-unstable";};
     nixpkgsMaster = {url = "github:nixos/nixpkgs/master";};

--- a/modules/nixos/kitsune-bootstrap.nix
+++ b/modules/nixos/kitsune-bootstrap.nix
@@ -11,7 +11,7 @@ in {
     enable = lib.mkEnableOption "kitsune-bootstrap";
 
     package = lib.mkOption {
-      default = self.inputs.holochain.packages.${pkgs.system}.holochain;
+      default = self.inputs.holochain.packages.${pkgs.system}.holochain.override {cargoExtraArgs = " --bin kitsune-bootstrap";};
       type = lib.types.package;
     };
 

--- a/modules/nixos/shared.nix
+++ b/modules/nixos/shared.nix
@@ -17,7 +17,7 @@
     # ]
     ;
 
-  nix.package = lib.mkDefault inputs.nixpkgsNix.legacyPackages.${pkgs.stdenv.system}.nixVersions.nix_2_20;
+  nix.package = lib.mkDefault inputs.nixpkgsNix.legacyPackages.${pkgs.stdenv.system}.nixVersions.nix_2_21;
 
   nix.settings.extra-platforms =
     lib.mkIf pkgs.stdenv.isDarwin ["x86_64-darwin" "aarch64-darwin"];


### PR DESCRIPTION
fixes #93.
fixes #94.

---

`nix build`ing a derivation that pulls in all existing darwin/nixos configurations seemed the simplest option here.

51 minutes is on the longer side of CI runs, however IMO it's acceptable when building OS configurations on free github runners. i'm curious to see how the "magic-nix-cache" helps for subsequent runs.

- [x] debug darwin jobs having an empty `result/` 
- [x] debug darwin jobs appearing to use an older nix leading to errors
- [x] clean up commit history
- [x] time-boxed attempt (before EOD 20240614) attempt to improve CI runtime