### PR TITLE
feat: add linux-builder-02, re-add macos-0{1,4}, rework github-runner module

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -8,6 +8,7 @@ keys:
   - &jost-s D299483493EAE6B2B3D892B6D33548FA55FF167F
   - &dweb-reverse-proxy age1ygzy9clj0xavlmau0ham7j5nw8yy4z0q8hvkfpdgwc4fcr8nufpqrdxgvx
   - &linux-builder-01 age1kxkr407jz77ljrhgsfwfmv2yvqjprc6unvx389xp2f48xj8r0vqq2wew5r
+  - &linux-builder-02 age1vlxerq9j9jd00qvxj2gxds9re4dz2djqmllkhzsf44gz9a5y4ghs7807h9
   - &tfgrid-shared age194xfar0gfdauu2dcxwqk9lh9d0vjfrzzs2ke0ppanpwv9eqxzs2qp7q7cn
 
 creation_rules:
@@ -25,6 +26,10 @@ creation_rules:
     key_groups:
     - age:
       - *linux-builder-01
+  - path_regex: ^secrets/linux-builder-02/[^/]+$
+    key_groups:
+    - age:
+      - *linux-builder-02
   - path_regex: ^secrets/nomad/.+$
     key_groups:
     - pgp:

--- a/flake.lock
+++ b/flake.lock
@@ -1425,11 +1425,11 @@
     },
     "nixpkgsGithubActionRunners": {
       "locked": {
-        "lastModified": 1709150264,
-        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
+        "lastModified": 1717786204,
+        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
+        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
         "type": "github"
       },
       "original": {

--- a/modules/flake-parts/darwinConfigurations.macos-04/README.md
+++ b/modules/flake-parts/darwinConfigurations.macos-04/README.md
@@ -1,0 +1,15 @@
+
+
+Commands that were performed on the machine for a successful deployment:
+
+```shell
+nix run .#ssh-macos-04
+echo "%admin            ALL = (ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+exit
+nix run .#ssh-macos-04
+exit
+nix run .\#deploy-macos-04
+nix run .\#linux-builder-01-ping-buildmachines
+nix run .\#linux-builder-02-ping-buildmachines
+```

--- a/modules/flake-parts/nixosConfigurations.linux-builder-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-01/configuration.nix
@@ -13,6 +13,12 @@
     inputs.srvos.nixosModules.roles-nix-remote-builder
     self.nixosModules.holo-users
     self.nixosModules.github-runner-multi-arch
+    {
+      config.services.github-runner-multi-arch = {
+        enable = true;
+        countOffset = 0;
+      };
+    }
     self.nixosModules.nix-build-distributor
 
     inputs.sops-nix.nixosModules.sops

--- a/modules/flake-parts/nixosConfigurations.linux-builder-02/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-02/configuration.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  inputs,
+  self,
+  pkgs,
+  lib,
+  ...
+}: {
+  imports = [
+    inputs.disko.nixosModules.disko
+    inputs.srvos.nixosModules.server
+    inputs.srvos.nixosModules.hardware-hetzner-online-amd
+    inputs.srvos.nixosModules.roles-nix-remote-builder
+    self.nixosModules.holo-users
+    self.nixosModules.github-runner-multi-arch
+    {
+      config.services.github-runner-multi-arch = {
+        enable = true;
+        countOffset = config.services.github-runner-multi-arch.count;
+      };
+    }
+
+    self.nixosModules.nix-build-distributor
+
+    inputs.sops-nix.nixosModules.sops
+
+    ../../nixos/shared.nix
+    ../../nixos/shared-nix-settings.nix
+    ../../nixos/shared-linux.nix
+  ];
+
+  networking.hostName = "linux-builder-02"; # Define your hostname.
+
+  hostName = "135.181.118.162";
+
+  nix.settings.max-jobs = 32;
+
+  roles.nix-remote-builder.schedulerPublicKeys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHVxIpF1Rfqz6i8JfhYswzYUM9cuL5p11LfVGSfPmw4Q root@github-runner-host"
+  ];
+
+  boot.loader.grub = {
+    efiSupport = false;
+  };
+  # boot.loader.systemd-boot.enable = true;
+  # boot.loader.efi.canTouchEfiVariables = true;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  systemd.network.networks."10-uplink".networkConfig.Address = "2a01:4f9:4b:1e9b::/64";
+
+  disko.devices.disk.nvme0n1 = {
+    device = "/dev/nvme0n1";
+    type = "disk";
+    content = {
+      type = "gpt";
+      partitions = {
+        boot = {
+          size = "1M";
+          type = "EF02"; # for grub MBR
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "btrfs";
+            extraArgs = ["-f"]; # Override existing partition
+            mountpoint = "/partition-root";
+            subvolumes = {
+              # Subvolume name is different from mountpoint
+              "/rootfs" = {
+                mountpoint = "/";
+              };
+              "/nix" = {
+                mountOptions = ["compress=zstd" "noatime"];
+                mountpoint = "/nix";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  sops.secrets.github-runners-token = {
+    key = "gh_hra2_pat4";
+    sopsFile = ../../../secrets/${config.networking.hostName}/secrets.yaml;
+  };
+
+  system.stateVersion = "23.11";
+}

--- a/modules/flake-parts/nixosConfigurations.linux-builder-02/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-02/configuration.nix
@@ -15,7 +15,8 @@
     self.nixosModules.github-runner-multi-arch
     {
       config.services.github-runner-multi-arch = {
-        enable = true;
+        # can't distribute jobs to the mac builders so this would disturb CI jobs.
+        enable = false;
         countOffset = config.services.github-runner-multi-arch.count;
       };
     }

--- a/modules/flake-parts/nixosConfigurations.linux-builder-02/default.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-02/default.nix
@@ -1,0 +1,12 @@
+{
+  self,
+  lib,
+  inputs,
+  ...
+}: {
+  flake.nixosConfigurations.linux-builder-02 = inputs.nixpkgs.lib.nixosSystem {
+    modules = [./configuration.nix];
+    system = "x86_64-linux";
+    specialArgs = self.specialArgs;
+  };
+}

--- a/modules/nixos/github-runner-multi-arch.nix
+++ b/modules/nixos/github-runner-multi-arch.nix
@@ -43,7 +43,7 @@ in {
         replace = true;
         ephemeral = true;
         inherit package;
-        extraLabels = [cfg.namePrefix];
+        extraLabels = [cfg.namePrefix config.networking.hostName];
         tokenFile = config.sops.secrets.github-runners-token.path;
         url = "https://github.com/holochain/holochain";
         extraPackages = config.environment.systemPackages;

--- a/modules/nixos/github-runner-multi-arch.nix
+++ b/modules/nixos/github-runner-multi-arch.nix
@@ -5,33 +5,52 @@
   pkgs,
   ...
 }: let
-  githubRunnersCfg = {
-    count = 16;
-    namePrefix = "multi-arch";
-  };
-
   nixpkgsGithubActionRunners' = pkgs.callPackage self.inputs.nixpkgsGithubActionRunners {};
 
   package = nixpkgsGithubActionRunners'.github-runner;
 
-  mkList = prefix: (builtins.genList
-    (x: "${prefix}${githubRunnersCfg.namePrefix}-${builtins.toString x}")
-    githubRunnersCfg.count);
-in {
-  services.github-runners =
-    lib.genAttrs
-    (mkList "")
-    (_: {
-      replace = true;
-      ephemeral = true;
-      inherit package;
-      extraLabels = [githubRunnersCfg.namePrefix];
-      tokenFile = config.sops.secrets.github-runners-token.path;
-      url = "https://github.com/holochain/holochain";
-      extraPackages = config.environment.systemPackages;
-    });
+  mkList = builtins.genList
+    (x: "${cfg.namePrefix}-${builtins.toString (x+cfg.countOffset)}")
+    cfg.count;
 
-  nixpkgs.config.permittedInsecurePackages = [
-    "nodejs-16.20.2"
-  ];
+    cfg = config.services.github-runner-multi-arch;
+in {
+  options.services.github-runner-multi-arch = {
+    enable = lib.mkEnableOption "self-hosted multi-arch github runner on holochain/holochain";
+    count = lib.mkOption {
+      description = "how many runners are spawned";
+      default = 16;
+      type = lib.types.int;
+    };
+
+    countOffset = lib.mkOption {
+      description = "offset to the count for numbering the runners";
+      default = 0;
+      type = lib.types.int;
+    };
+
+    namePrefix= lib.mkOption {
+      description = "prefix for the runner names";
+      default = "multi-arch";
+      type = lib.types.str;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.github-runners =
+      lib.genAttrs mkList
+      (_: {
+        replace = true;
+        ephemeral = true;
+        inherit package;
+        extraLabels = [cfg.namePrefix];
+        tokenFile = config.sops.secrets.github-runners-token.path;
+        url = "https://github.com/holochain/holochain";
+        extraPackages = config.environment.systemPackages;
+      });
+
+    nixpkgs.config.permittedInsecurePackages = [
+      "nodejs-16.20.2"
+    ];
+  };
 }

--- a/modules/nixos/macos-remote-builder.nix
+++ b/modules/nixos/macos-remote-builder.nix
@@ -31,6 +31,7 @@
     # setup ssh credentials for remote builds
     mkdir -p /Users/builder/.ssh/
     echo "command=\"${pkgs.flock}/bin/flock -s /nix/var/nix/gc.lock nix-daemon --stdio\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ1K1ZYBnf3UqQbln5Z8DLYsXyJo6pRAFISPQ7lJZpoO root@linux-builder-01" > /Users/builder/.ssh/authorized_keys
+    echo "command=\"${pkgs.flock}/bin/flock -s /nix/var/nix/gc.lock nix-daemon --stdio\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6c6N8EnOvMt2GyS3Gp4akujyCIRKi1cXohf8+cXmKc root@linux-builder-02" >> /Users/builder/.ssh/authorized_keys
     chown -R builder:staff /Users/builder/.ssh/
     chmod 700 /Users/builder/.ssh/
     chmod 400 /Users/builder/.ssh/authorized_keys

--- a/modules/nixos/nix-build-distributor.nix
+++ b/modules/nixos/nix-build-distributor.nix
@@ -54,7 +54,9 @@
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "aarch64-darwin";
-      maxJobs = 3;
+      # had a factory reset, still needs setting up
+      maxJobs = 0;
+      # maxJobs = 3;
       speedFactor = 2;
       supportedFeatures = config.nix.settings.experimental-features;
     }

--- a/modules/nixos/nix-build-distributor.nix
+++ b/modules/nixos/nix-build-distributor.nix
@@ -9,7 +9,7 @@
   nix.buildMachines = [
     # macos-01
     # - m1 cpu
-    # - system integrity protection disabled
+    # - system integrity protection enabled
     {
       hostName = "167.235.13.208";
       sshUser = "builder";
@@ -47,15 +47,13 @@
 
     # macos-04
     # - m1 cpu
-    # - system integrity protection disabled
+    # - system integrity protection enabled
     {
       hostName = "167.235.38.111";
       sshUser = "builder";
       protocol = "ssh-ng";
       system = "aarch64-darwin";
-      # had a factory reset, still needs setting up
-      maxJobs = 0;
-      # maxJobs = 3;
+      maxJobs = 3;
       speedFactor = 2;
       supportedFeatures = config.nix.settings.experimental-features;
     }

--- a/modules/nixos/nix-build-distributor.nix
+++ b/modules/nixos/nix-build-distributor.nix
@@ -14,10 +14,9 @@
       hostName = "167.235.13.208";
       sshUser = "builder";
       protocol = "ssh-ng";
-      system = "x86_64-darwin";
-      # has a broken nix installation
-      maxJobs = 0;
-      speedFactor = 1;
+      system = "aarch64-darwin";
+      maxJobs = 3;
+      speedFactor = 2;
       supportedFeatures = config.nix.settings.experimental-features;
     }
 

--- a/secrets/linux-builder-02/secrets.yaml
+++ b/secrets/linux-builder-02/secrets.yaml
@@ -1,0 +1,21 @@
+gh_hra2_pat4: ENC[AES256_GCM,data:RhbPMa7JpZtxZzIWKBYdLodwYZhCupWmzZcIT/+1OUYFyMlFxNXWvA==,iv:XEZmlAtO+jLZlTXlSmLvi1VVUbLYe1kVmqw8ylCq7d8=,tag:EkggPJa3Du1frkxzl/8A7g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1vlxerq9j9jd00qvxj2gxds9re4dz2djqmllkhzsf44gz9a5y4ghs7807h9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwVHQvbGwwaXkvdk15WW90
+            VVUvZDdKUGZIM3lFUERiWVUraTVHUm8vWHhzClM2WU5VK3BVU2dlanlaWHlkQitn
+            N0lJN2FFOU1pdHFhcGQ4SnBtZWZFcEEKLS0tIHM1eWc0Wnp2YzBBRDhpbUY4SDB5
+            ZGJuKy9CVGkyWW14YlJDWXRZcnZWQXcKof00tuXDus26+8xbKjyzkvY5JcoAxHZZ
+            X0lVNQW1DU5/Jy5NRshnBlRm5WifnwE0SbjF2lpTSmgOSBCYByMTsg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-06-06T09:07:57Z"
+    mac: ENC[AES256_GCM,data:/ILjd3srjGGxw42P6HMJvlQJK2QlNgnJpbxhlPIahDzSfhGSJcPpl6BSuU5ETCaIsALuyFARtRKJe3eBYYLAVb9hv7rjPvhkbNCviSgfKwM4HUMuxyk7g88OPE4T6rANswFwz6IuZddAo0TtnAZYHoy7CfHWGubi9VnlSNC88PQ=,iv:t1yz+yVFleNbmIvJ2Vn8vQWoick7qrV2fmvdeT/UaZ0=,tag:xwKWS51eFZ4j3WVuz4a/Pg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
this was sparked by #110 as the fate of its filesystem/drive has been unclear.

the machine had previously been powered off as it had a timed-out evaluation install of a MS Windows Server OS. as its hardware configuration is the same as linux-builder-01's, it was a very low-hanging fruit to get it up and running as a clone of that.

open questions


- [x] debug distribution to macos builders. currently they deny SSH access from linux-builder-02
- [ ] ~~re-enable linux-builder-02 as a github-runner~~ out of scope for now as the fate of the machine is unclear
    - [ ] reduce the number of runners per host to keep a balance of runners and macos builders? otherwise the macos builder could be overwhelmed as they now receive double the jobs


fixes #97.
fixes #113. 