### PR TITLE
feat(apps-deploy): add direct deployment script

### DIFF
--- a/modules/flake-parts/apps.deploy-/linux.nix
+++ b/modules/flake-parts/apps.deploy-/linux.nix
@@ -30,7 +30,41 @@
           inherit (config.config) hostName;
         });
       };
+
+    mkLinuxDeployDirect = {
+      attrName,
+      hostName,
+    }:
+      pkgs.writeShellScript "deploy-direct-${hostName}" ''
+        set -Eeo pipefail
+        export PATH="${lib.makeBinPath (with pkgs; [
+          nix
+          git
+          coreutils
+        ])}:$PATH"
+        set -uxeE -o pipefail
+
+        closure_path=$(nix build --print-out-paths --refresh github:holochain/holochain-infra/deploy/${attrName}#nixosConfigurations.${attrName}.config.system.build.toplevel)
+
+        nix-copy-closure --to root@${hostName} $closure_path
+
+        ssh root@${hostName} "$closure_path/bin/switch-to-configuration ''${1:-switch}"
+      '';
+
+
+    mkLinuxDeployDirectApp = attrName: config:
+      lib.nameValuePair "deploy-direct-${attrName}" {
+        type = "app";
+        program = builtins.toString (mkLinuxDeployDirect {
+          inherit attrName;
+          inherit (config.config) hostName;
+        });
+      };
   in {
-    config.apps = lib.mapAttrs' mkLinuxDeployApp self.nixosConfigurations;
+    config.apps =
+    (lib.mapAttrs' mkLinuxDeployApp self.nixosConfigurations) //
+    (lib.mapAttrs' mkLinuxDeployDirectApp self.nixosConfigurations) //
+    {}
+    ;
   };
 }


### PR DESCRIPTION
this uses the local machien to build and copies the resulting closure to the target system. this was necessary for small builders that ran out of memory building the holochain dependencies.

preliminary solution to #114

cc @r-vdp 