### PR TITLE
feat(flake): switch back to upstream nix-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,16 +254,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1715935620,
-        "narHash": "sha256-b60zHhqS67LW9nTxl7p6ba2OdXJAMoMclEYHbRPpwKM=",
-        "owner": "steveeJ-forks",
+        "lastModified": 1718440858,
+        "narHash": "sha256-iMVwdob8F6P6Ib+pnhMZqyvYI10ZxmvA885jjnEaO54=",
+        "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "9f51e374d7cc7fdf7c9b2578a5757b92d028e2ea",
+        "rev": "58b905ea87674592aa84c37873e6c07bc3807aba",
         "type": "github"
       },
       "original": {
-        "owner": "steveeJ-forks",
-        "ref": "fork-fix-launchd-calendar-interval",
+        "owner": "LnL7",
         "repo": "nix-darwin",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,7 @@
     microvm.inputs.nixpkgs.follows = "nixpkgs";
 
     # nix darwin
-    darwin.url = "github:steveeJ-forks/nix-darwin/fork-fix-launchd-calendar-interval";
-
+    darwin.url = "github:LnL7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     # home manager


### PR DESCRIPTION
fix #91 

- [x] deploy macos-06 
- [x] manually test on macos-06
- [x] deploy all other macos machines

---

<details>
<summary>test log</summary>

verifying the functionality of macos-06 as a builder
```
[root@linux-builder-01:~/src/holochain-infra]# nix build -j0 --builders "ssh-ng://builder@208.52.154.135 x86_64-darwin - 6 2 nix-command,flakes,ca-derivations,impure-derivations,recursive-nix - -" .#darwinConfigurations.macos-06.config.system.build.toplevel
</details>
[root@linux-builder-01:~/src/holochain-infra]# ll result
lrwxrwxrwx 1 root root 96 Jun 17 13:48 result -> /nix/store/v24fagczxcjwd29xrhravs8b1blzpdy5-darwin-system-23.11.20240317.614b461+darwin4.58b905e
```

verifying the GC schedule
```
administrator@22627:~/ > sudo launchctl print system/org.nixos.nix-gc
system/org.nixos.nix-gc = {
	active count = 0
	path = /Library/LaunchDaemons/org.nixos.nix-gc.plist
	type = LaunchDaemon
	state = not running

	program = /bin/sh
	arguments = {
		/bin/sh
		-c
		exec /nix/store/2gsd4rlwcsm2zjy5cpmgbnv4f228j9xf-nix-gc
	}

	default environment = {
		PATH => /usr/bin:/bin:/usr/sbin:/sbin
	}

	environment = {
		NIX_REMOTE => daemon
		XPC_SERVICE_NAME => org.nixos.nix-gc
	}

	domain = system
	minimum runtime = 10
	exit timeout = 5
	runs = 2
	last exit code = 0

	event triggers = {
		org.nixos.nix-gc.268435468 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 35
			}
		}
		org.nixos.nix-gc.268435467 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 28
			}
		}
		org.nixos.nix-gc.268435466 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 21
			}
		}
		org.nixos.nix-gc.268435471 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 56
			}
		}
		org.nixos.nix-gc.268435465 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 14
			}
		}
		org.nixos.nix-gc.268435470 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 49
			}
		}
		org.nixos.nix-gc.268435464 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 7
			}
		}
		org.nixos.nix-gc.268435463 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 0
			}
		}
		org.nixos.nix-gc.268435469 => {
			keepalive = 0
			service = org.nixos.nix-gc
			stream = com.apple.launchd.calendarinterval
			monitor = com.apple.UserEventAgent-System
			descriptor = {
				"Minute" => 42
			}
		}
	}

	event channels = {
		"com.apple.launchd.calendarinterval" = {
			port = 0x37c9b
			active = 0
			managed = 1
			reset = 0
			hide = 0
			watching = 1
		}
	}

	spawn type = daemon (3)
	jetsam priority = 40
	jetsam memory limit (active) = (unlimited)
	jetsam memory limit (inactive) = (unlimited)
	jetsamproperties category = daemon
	jetsam thread limit = 32
	cpumon = default
	probabilistic guard malloc policy = {
		activation rate = 1/1000
		sample rate = 1/0
	}

	properties = inferred program | managed LWCR | has LWCR
}
```