### PR TITLE
x64-linux-dev-01: accept GIT_AUTHOR_* env vars in SSH sessions; add nixos-vscode-server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -955,18 +955,6 @@
         "url": "https://github.com/ThetaSinner.keys"
       }
     },
-    "keys_zippy": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-0OoNLGRMmWmezTJGQdbQno6BCYHnuuuUKVfY48chkOw=",
-        "type": "file",
-        "url": "https://github.com/zippy.keys"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://github.com/zippy.keys"
-      }
-    },
     "lair": {
       "flake": false,
       "locked": {
@@ -1674,7 +1662,6 @@
         "keys_jost-s": "keys_jost-s",
         "keys_steveej": "keys_steveej",
         "keys_thetasinner": "keys_thetasinner",
-        "keys_zippy": "keys_zippy",
         "microvm": "microvm",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-generators": "nixos-generators",

--- a/flake.lock
+++ b/flake.lock
@@ -586,6 +586,24 @@
         "systems": "systems_5"
       },
       "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
         "lastModified": 1709126324,
         "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
@@ -1260,6 +1278,25 @@
         "type": "github"
       }
     },
+    "nixos-vscode-server": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1713958148,
+        "narHash": "sha256-8PDNi/dgoI2kyM7uSiU4eoLBqUKoA+3TXuz+VWmuCOc=",
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "rev": "fc900c16efc6a5ed972fb6be87df018bcf3035bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-vscode-server",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1677534593,
@@ -1521,6 +1558,20 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1682134069,
+        "narHash": "sha256-TnI/ZXSmRxQDt2sjRYK/8j8iha4B4zP2cnQCZZ3vp7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd901ef4bf93499374c5af385b2943f5801c0833",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "npm-to-nix": {
       "flake": false,
       "locked": {
@@ -1665,6 +1716,7 @@
         "microvm": "microvm",
         "nixos-anywhere": "nixos-anywhere",
         "nixos-generators": "nixos-generators",
+        "nixos-vscode-server": "nixos-vscode-server",
         "nixpkgs": [
           "nixpkgs-23-11"
         ],
@@ -1923,12 +1975,27 @@
         "type": "github"
       }
     },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "threefold-rfs": {
       "inputs": {
         "crane": [
           "crane"
         ],
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -73,10 +73,12 @@
       flake = false;
     };
 
-    keys_zippy = {
-      url = "https://github.com/zippy.keys";
-      flake = false;
-    };
+    # hash mismatch 20240710
+    # keys_zippy = {
+    #   url = "https://github.com/zippy.keys";
+    #   flake = false;
+    # };
+
     keys_artbrock = {
       url = "https://github.com/artbrock.keys";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,8 @@
     holoNixpkgs.url = "https://hydra.holo.host/channel/custom/holo-nixpkgs/2112/holo-nixpkgs/nixexprs.tar.xz";
 
     nixpkgsPulumi.url = "github:steveej-forks/nixpkgs/pulumi-version-bump";
+
+    nixos-vscode-server.url = "github:nix-community/nixos-vscode-server";
   };
 
   outputs = inputs @ {

--- a/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
@@ -31,8 +31,8 @@ in {
       };
 
       services.openssh.settings.AcceptEnv = builtins.concatStringsSep " " [
-        "GIT_AUTHOR_NAME"
-        "GIT_AUTHOR_EMAIL"
+        "GIT_AUTHOR_*"
+        "GIT_COMMITTER_*"
       ];
     }
 

--- a/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
@@ -60,6 +60,8 @@ in {
 
   nix.settings.system-features = [
     "big-parallel"
+    "kvm"
+    "nixos-test"
   ];
 
   networking = {

--- a/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
@@ -27,6 +27,9 @@ in {
       home-manager.users.dev = {pkgs, ...}: {
         home.packages = [
           # additional packages for this user go here
+          pkgs.nil
+          pkgs.wget
+          pkgs.file
         ];
       };
 
@@ -40,6 +43,19 @@ in {
     {
       services.devMinio.enable = true;
     }
+
+    inputs.nixos-vscode-server.nixosModules.default
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      services.vscode-server = {
+        enable = true;
+        installPath = "$HOME/.vscodium-server";
+        nodejsPackage = pkgs.nodejs_18;
+      };
+    })
   ];
 
   nix.settings.system-features = [

--- a/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.x64-linux-dev-01/configuration.nix
@@ -29,6 +29,11 @@ in {
           # additional packages for this user go here
         ];
       };
+
+      services.openssh.settings.AcceptEnv = builtins.concatStringsSep " " [
+        "GIT_AUTHOR_NAME"
+        "GIT_AUTHOR_EMAIL"
+      ];
     }
 
     ../../nixos/dev-minio.nix


### PR DESCRIPTION
* this allows devs to override this variable via their SSH config
* enables the vscodium remote-SSH extensions to use the host as a remote server