### PR TITLE
feat(macos-remote-bulder): authorize buildbot-nix-0 and enable remote building

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-13]
+        os: [ ]
     name: OS
     runs-on: ${{ matrix.os }}
     permissions:

--- a/modules/flake-parts/apps.ssh-/default.nix
+++ b/modules/flake-parts/apps.ssh-/default.nix
@@ -31,9 +31,46 @@
       config.apps =
         let
           configurations = (self.darwinConfigurations // self.nixosConfigurations);
+
           individual = lib.mapAttrs' mkSshApp configurations;
+
+          distributers = {
+            inherit (self.nixosConfigurations) linux-builder-01 buildbot-nix-0;
+          };
+          mkBuilderPingCommand =
+            distributorConfig:
+            builtins.concatStringsSep ''&& '' (
+              builtins.map (buildMachineAttrs: ''
+                (timeout 10s ssh -No StrictHostKeyChecking=accept-new ${buildMachineAttrs.sshUser}@${buildMachineAttrs.hostName} || true) && nix store info --store 'ssh-ng://${buildMachineAttrs.sshUser}@${buildMachineAttrs.hostName}'
+              '') distributorConfig.config.nix.buildMachines
+            );
+
+          /*
+            adds one command for every host that has the nix-build-distributor module imported.
+            this command will accept the host keys of all the configured buildMachines and check whether nix can successfully establish a remote connection.
+            note that execution takes 10 seconds per buildMachine, because the the key acceptance command hangs indefinitely in the success case.
+
+            run for example: `nix run .\#ssh-buildbot-nix-0-ping-builders
+          */
+          distributerNixPingBuilders = lib.mapAttrs' (
+            attrName: config:
+            lib.nameValuePair "${prefix}${attrName}-ping-builders" {
+              type = "app";
+              program = builtins.toString (
+                pkgs.writeShellScript "${prefix}${attrName}-ping-builders" ''
+                  exec ${
+                    mkSsh {
+                      inherit attrName;
+                      inherit (config.config) hostName deployUser;
+                    }
+                  } bash -c "${lib.strings.escapeShellArg (mkBuilderPingCommand config)}"
+                ''
+              );
+            }
+          ) distributers;
         in
         individual
+        // distributerNixPingBuilders
         // {
           "${prefix}all" = {
             type = "app";

--- a/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
@@ -204,8 +204,8 @@
     buildSystems = [
       "x86_64-linux"
       # "aarch64-linux"
-      # "x86_64-darwin"
-      # "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
     domain = config.passthru.buildbot-nix.appFqdn;
     outputsPath = "/var/www/buildbot/nix-outputs/";

--- a/modules/nixos/macos-remote-builder.nix
+++ b/modules/nixos/macos-remote-builder.nix
@@ -26,7 +26,7 @@
     # setup ssh credentials for remote builds
     mkdir -p /Users/builder/.ssh/
     echo "command=\"${pkgs.flock}/bin/flock -s /nix/var/nix/gc.lock nix-daemon --stdio\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ1K1ZYBnf3UqQbln5Z8DLYsXyJo6pRAFISPQ7lJZpoO root@linux-builder-01" > /Users/builder/.ssh/authorized_keys
-    echo "command=\"${pkgs.flock}/bin/flock -s /nix/var/nix/gc.lock nix-daemon --stdio\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP6c6N8EnOvMt2GyS3Gp4akujyCIRKi1cXohf8+cXmKc root@linux-builder-02" >> /Users/builder/.ssh/authorized_keys
+    echo "command=\"${pkgs.flock}/bin/flock -s /nix/var/nix/gc.lock nix-daemon --stdio\" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBqhOu9oMwDlfQFRTBKAdCe4IZmcGrrbDABP576Q+BYW root@buildbot-nix-0" >> /Users/builder/.ssh/authorized_keys
     chown -R builder:staff /Users/builder/.ssh/
     chmod 700 /Users/builder/.ssh/
     chmod 400 /Users/builder/.ssh/authorized_keys


### PR DESCRIPTION
once this PR is finished buildbot-nix will be able to build the darwin checks as well.

- [x] authorize buildbot-nix-0 on darwin builders
- [x] enable darwin builders on buildbot-nix-0
- [x] disable github-actions