### PR TITLE
feat(linux-builder-2): block outgoing traffic on uplink destined to private IPs

### DIFF
--- a/modules/flake-parts/nixosConfigurations.linux-builder-2/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.linux-builder-2/configuration.nix
@@ -36,7 +36,7 @@
     self.nixosModules.zerotier
     {
       zerotier-stealth.enable = true;
-      zerotier-stealth.autostart = false;
+      zerotier-stealth.autostart = true;
 
       # zerotier makes outgoing requests to private ranges, this trips up the detection system at hetzner.
       networking.nftables = {


### PR DESCRIPTION
fixes #166.

the activation of zerotier has triggered an abuse warning on hetzner, likely because of a big number of packets that are caught by this filter.