### PR TITLE
feat: add nomad containers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -388,6 +388,29 @@
         "type": "github"
       }
     },
+    "extra-container": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734005403,
+        "narHash": "sha256-vgh3TqfkFdnPxREBedw4MQehIDc3N8YyxBOB45n+AvU=",
+        "owner": "erikarvstedt",
+        "repo": "extra-container",
+        "rev": "f4de6c329b306a9d3a9798a30e060c166f781baa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "erikarvstedt",
+        "repo": "extra-container",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1696426674,
@@ -1471,6 +1494,7 @@
         "darwin": "darwin",
         "devshell": "devshell",
         "disko": "disko",
+        "extra-container": "extra-container",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
         "flake-utils": "flake-utils",

--- a/flake.nix
+++ b/flake.nix
@@ -377,10 +377,6 @@
               # Automatically inherit any build inputs from `my-crate`
               inputsFrom = [
                 devshell
-                (self'.packages.postbuildstepper.override {
-                  inherit craneLib;
-                  stdenv = (cranePkgs.stdenvAdapters.useMoldLinker cranePkgs.stdenv);
-                })
               ];
 
               # Extra inputs (only used for interactive development)

--- a/flake.nix
+++ b/flake.nix
@@ -590,6 +590,23 @@
 
           config = {
             containers.nomadServer = {
+              privateNetwork = true;
+              hostAddress = "10.250.0.1";
+              localAddress = "10.250.0.2";
+
+              forwardPorts = [
+                {
+                  containerPort = 4646;
+                  hostPort = 4646;
+                  protocol = "tcp";
+                }
+                {
+                  containerPort = 4647;
+                  hostPort = 4647;
+                  protocol = "tcp";
+                }
+              ];
+
               config =
                 { ... }:
                 {
@@ -606,6 +623,11 @@
                       };
                     };
                   };
+
+                  networking.firewall.allowedTCPPorts = [
+                    4646
+                    4647
+                  ];
                 };
             };
           };
@@ -615,6 +637,10 @@
 
           config = {
             containers.nomadClient = {
+              privateNetwork = true;
+              hostAddress = "10.250.0.1";
+              localAddress = "10.250.0.3";
+
               config =
                 { ... }:
                 {
@@ -629,6 +655,7 @@
                     settings = {
                       client = {
                         enabled = true;
+                        servers = [ "10.250.0.1" ];
                       };
                     };
                   };


### PR DESCRIPTION
Goals of this PR:
- [x] Add a NixOS container for running the Nomad Server
- [x] Add one or more NixOS containers for running the Nomad Client
- [x] Allow the server to see the client(s)
- [ ] Add an example job that can run on the setup
- [ ] Create a private network with a network bridge or something more robust so the containers can communicate without going through the host machine