### PR TITLE
Add Visvere customer channel

### DIFF
--- a/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
@@ -362,7 +362,7 @@
             // {
               PBS_CHANNELS_DIRECTORY = config.passthru.hydra.channelsDirectory;
               PBS_JOBSETS_DIRECTORY = config.passthru.hydra.jobsetsDirectory;
-              SOURCE_BRANCH_CHANNELS = builtins.concatStringsSep "," [ "scale-testing" ];
+              SOURCE_BRANCH_CHANNELS = builtins.concatStringsSep "," [ "scale-testing" "visvere" ];
             };
           command = [ (lib.getExe' self.packages.${pkgs.system}.postbuildstepper "postbuildstepper") ];
         }

--- a/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
+++ b/modules/flake-parts/nixosConfigurations.buildbot-nix-0/configuration.nix
@@ -362,7 +362,10 @@
             // {
               PBS_CHANNELS_DIRECTORY = config.passthru.hydra.channelsDirectory;
               PBS_JOBSETS_DIRECTORY = config.passthru.hydra.jobsetsDirectory;
-              SOURCE_BRANCH_CHANNELS = builtins.concatStringsSep "," [ "scale-testing" "visvere" ];
+              SOURCE_BRANCH_CHANNELS = builtins.concatStringsSep "," [
+                "scale-testing"
+                "visvere"
+              ];
             };
           command = [ (lib.getExe' self.packages.${pkgs.system}.postbuildstepper "postbuildstepper") ];
         }


### PR DESCRIPTION
This adds a customer channel for Visvere so that we can manage legacy network node deployments.