### PR TITLE
chore(flake): update keys_thetasinner

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,7 +890,7 @@
     "keys_thetasinner": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-sDa25rA0Qb8ASDLWBXQ3YIDVwDoK56cgQGow+3aWNfE=",
+        "narHash": "sha256-FSsAYcIFaPwzVrCORsRm5691hB638qrbca53DqgcVjA=",
         "type": "file",
         "url": "https://github.com/ThetaSinner.keys"
       },


### PR DESCRIPTION
noticed it's outdated when deploying

>        error: NAR hash mismatch in input 'https://github.com/ThetaSinner.keys?narHash=sha256-sDa25rA0Qb8ASDLWBXQ3YIDVwDoK56cgQGow%2B3aWNfE%3D', expected 'sha256-sDa25rA0Qb8ASDLWBXQ3YIDVwDoK56cgQGow+3aWNfE=' but got 'sha256-FSsAYcIFaPwzVrCORsRm5691hB638qrbca53DqgcVjA='


cc @ThetaSinner 
