### PR TITLE
add jetttech age key for holo team ci paths

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -6,6 +6,7 @@
 keys:
   - &steveej 6F7069FE6B96E894E60EC45C6EEFA706CB17E89B
   - &age_steveej age1tkvtkw62xy90xc5xdcq836wgyrwlwmdslh76cete5g98vvvhj34qvwdw0g
+  - &age_jetttech age1a4zj9yq55aav2xtxmxrx3aaz9d0a3a7gq4d92zfxlrvzuccycp9q3crf9v
   - &jost-s D299483493EAE6B2B3D892B6D33548FA55FF167F
   - &age_r-vdp age1wm7aec0vd5trqqvk6n97kh8r3x0jpue9gne9enr92kdjk63f5e8s9gjy0x
   - &dev age1fnmdutanvfsrhadap3qsmncjfa85x82qy8svy98ma4p37dglq45stcwk28
@@ -100,6 +101,7 @@ creation_rules:
           - *buildbot-nix-0
           - *aarch64-linux-builder-0
           - *age_r-vdp
+          - *age_jetttech
   - path_regex: ^secrets/buildbot-nix-0/[^/]+$
     key_groups:
       - pgp:
@@ -107,6 +109,7 @@ creation_rules:
         age:
           - *buildbot-nix-0
           - *age_r-vdp
+          - *age_jetttech
   - path_regex: ^secrets/nomad/.+$
     key_groups:
       - pgp:


### PR DESCRIPTION
Adds jetttech age key to `buildbot-nix-0` and `github-secrets` paths.