### PR TITLE
chore: Update runner software

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1373,11 +1373,11 @@
     },
     "nixpkgsGithubActionRunners": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Our runners have gone offline with an out of date version error. Following the instructions here to update them https://github.com/holochain/holochain-infra?tab=readme-ov-file#upgrading-the-github-runner-version