### PR TITLE
chore: Add ThetaSinner age key to manage builder secrets

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -25,6 +25,7 @@ keys:
   - &stun-0_main_infra_holo_host age162clfdx3zc7qr5au7gyxmhs44lfezt8qzpf3a2ppqh5r628enf0q70prc0
   - &mamading_age age1qr2rhvj7qdfxf7cpja52ssxp93gvmhecdkxpm6q2h93xf3y73urs6ssnmk
   - &age_jetttech age1a4zj9yq55aav2xtxmxrx3aaz9d0a3a7gq4d92zfxlrvzuccycp9q3crf9v
+  - &age_thetasinner age1t3p2a5djefdsdxstv68mg67ekey623uvvgmv0tx2yy0lajfyyucq03clze
 
 creation_rules:
   - path_regex: ^(.+/|)secrets/[^/]+$
@@ -76,6 +77,7 @@ creation_rules:
           - *age_steveej
           # - *age_r-vdp
           - *mamading_age
+          - *age_thetasinner
         pgp:
           - *steveej
   - path_regex: ^secrets/linux-builder-shared/[^/]+$
@@ -84,6 +86,7 @@ creation_rules:
           - *linux-builder-01
           - *linux-builder-2
           - *mamading_age
+          - *age_thetasinner
         pgp:
           - *steveej
   - path_regex: ^secrets/linux-builder-2/[^/]+$
@@ -92,6 +95,7 @@ creation_rules:
           - *linux-builder-2
           - *age_steveej
           - *mamading_age
+          - *age_thetasinner
         pgp:
           - *steveej
   - path_regex: ^secrets/x64-linux-dev-01/[^/]+$


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret management configuration to include a new authorized key for accessing specific secret paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->